### PR TITLE
feat(sscsid-keeper): support pdb, mount volumes, tests, secret types

### DIFF
--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -12,7 +12,7 @@ chart-dirs:
   - charts
 chart-repos:
   # - dandydeveloper=https://dandydeveloper.github.io/charts/
-# helm-extra-args: "--timeout 600s"  
+helm-extra-args: "--timeout 120s"  
 validate-chart-schema: false
 validate-maintainers: true
 validate-yaml: true

--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -17,4 +17,5 @@ validate-chart-schema: false
 validate-maintainers: true
 validate-yaml: true
 exclude-deprecated: true
-excluded-charts: []
+excluded-charts:
+  - sscsid-keeper # Can sadly not be fully tested due to MountVolume.SetUp failed for volume "sscsid-keeper" : rpc error: code = Unknown desc = failed to mount secrets store objects for pod sscsid-keeper-0562g0ya8w/sscsid-keeper-0562g0ya8w-5bbf784b44-wxnzj, err: rpc error: code = Unknown desc = failed to mount objects, error: failed to get objectType:secret, objectName:my-special-example-key, objectVersion:: ManagedIdentityCredential authentication failed. ManagedIdentityCredential authentication failed. the requested identity isn't assigned to this resource

--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -1,0 +1,20 @@
+# SPDX-SnippetBegin
+# SPDX-License-Identifier: Apache License 2.0
+# SPDX-SnippetCopyrightText: 2024 © Argo Project, argoproj/argo-helm
+# SPDX-SnippetCopyrightText: 2024 © Unique AG
+# SPDX-SnippetEnd
+## Reference: https://github.com/helm/chart-testing/blob/master/doc/ct_lint-and-install.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Install Stage
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts
+chart-repos:
+  # - dandydeveloper=https://dandydeveloper.github.io/charts/
+# helm-extra-args: "--timeout 600s"  
+validate-chart-schema: false
+validate-maintainers: true
+validate-yaml: true
+exclude-deprecated: true
+excluded-charts: []

--- a/.github/configs/kind-config.yaml
+++ b/.github/configs/kind-config.yaml
@@ -1,0 +1,12 @@
+# SPDX-SnippetBegin
+# SPDX-License-Identifier: Apache License 2.0
+# SPDX-SnippetCopyrightText: 2024 © Argo Project, argoproj/argo-helm
+# SPDX-SnippetCopyrightText: 2024 © Unique AG
+# SPDX-SnippetEnd
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker
+  - role: worker
+  - role: worker

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -83,11 +83,11 @@ jobs:
             helm unittest $chart
           done
 
-      # - name: Create kind cluster
-      #   uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
-      #   if: steps.list-changed.outputs.changed == 'true'
-      #   with:
-      #     config: .github/configs/kind-config.yaml
+      - name: Create kind cluster
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        if: steps.list-changed.outputs.changed == 'true'
+        with:
+          config: .github/configs/kind-config.yaml
 
       # - name: Deploy latest ArgoCD CRDs when testing ArgoCD extensions
       #   if: |
@@ -111,6 +111,6 @@ jobs:
       #     helm repo add bitnami https://charts.bitnami.com/bitnami
       #     helm install redis bitnami/redis --wait --namespace redis --set auth.password=argocd --set architecture=standalone
 
-      # - name: Run chart-testing (install)
-      #   run: ct install --config ./.github/configs/ct-install.yaml
-      #   if: steps.list-changed.outputs.changed == 'true'
+      - name: Run chart-testing (install)
+        run: ct install --config ./.github/configs/ct-install.yaml
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -88,13 +88,16 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         with:
           config: .github/configs/kind-config.yaml
-
-      - name: Deploy latest CRDs (secrets-store.csi.x-k8s.io) when testing affected charts
-        if: |
-          contains(steps.list-changed.outputs.changed_charts, 'sscsid-keeper')
-        run: |
-          helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
-          helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure
+      
+      # - name: Deploy latest CRDs (secrets-store.csi.x-k8s.io) when testing affected charts
+      #   if: |
+      #     contains(steps.list-changed.outputs.changed_charts, 'sscsid-keeper')
+      #   run: |
+      #     helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
+      #     helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure
+      # csi-secrets-store-provider-azure can not be tested properly for sscsid-keeper as the underlying Machine Identities are not present and thus the pods fail to start
+      # helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
+      # helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure
 
       # - name: Skip HPA tests of ArgoCD
       #   if: contains(steps.list-changed.outputs.changed_charts, 'argo-cd')

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -89,7 +89,7 @@ jobs:
         with:
           config: .github/configs/kind-config.yaml
 
-      - name: Deploy latest secrets-store-csi-driver CRDs when testing affected charts
+      - name: Deploy latest CRDs (secrets-store.csi.x-k8s.io) when testing affected charts
         if: |
           contains(steps.list-changed.outputs.changed_charts, 'sscsid-keeper')
         run: |

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -77,10 +77,6 @@ jobs:
       - run: helm plugin install https://github.com/helm-unittest/helm-unittest.git 
 
       - name: Run Unit Tests
-        if: |
-          contains(steps.list-changed.outputs.changed_charts, 'backend-service') ||
-          contains(steps.list-changed.outputs.changed_charts, 'web-app') ||
-          contains(steps.list-changed.outputs.changed_charts, 'ai-service')
         run: |
           for chart in ${{steps.list-changed.outputs.changed_charts}}; do
             echo "Unit testing chart: $chart"

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -89,14 +89,12 @@ jobs:
         with:
           config: .github/configs/kind-config.yaml
 
-      # - name: Deploy latest ArgoCD CRDs when testing ArgoCD extensions
-      #   if: |
-      #     contains(steps.list-changed.outputs.changed_charts, 'argocd-image-updater') ||
-      #     contains(steps.list-changed.outputs.changed_charts, 'argocd-apps')
-      #   run: |
-      #     helm repo add dandydeveloper https://dandydeveloper.github.io/charts/
-      #     helm dependency build charts/argo-cd/
-      #     helm template charts/argo-cd/ --set server.extensions.enabled=true -s templates/crds/* | kubectl apply -f -
+      - name: Deploy latest secrets-store-csi-driver CRDs when testing affected charts
+        if: |
+          contains(steps.list-changed.outputs.changed_charts, 'sscsid-keeper')
+        run: |
+          helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+          helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver
 
       # - name: Skip HPA tests of ArgoCD
       #   if: contains(steps.list-changed.outputs.changed_charts, 'argo-cd')

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -93,8 +93,8 @@ jobs:
         if: |
           contains(steps.list-changed.outputs.changed_charts, 'sscsid-keeper')
         run: |
-          helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
-          helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver
+          helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
+          helm install csi csi-secrets-store-provider-azure/csi-secrets-store-provider-azure
 
       # - name: Skip HPA tests of ArgoCD
       #   if: contains(steps.list-changed.outputs.changed_charts, 'argo-cd')

--- a/charts/sscsid-keeper/Chart.yaml
+++ b/charts/sscsid-keeper/Chart.yaml
@@ -1,16 +1,26 @@
 apiVersion: v2
 type: application
-icon: https://raw.githubusercontent.com/unique-ag/helm-charts/main/icon.svg
+icon: https://www.unique.ch/hubfs/unique_assets/favicon/glyph_caumasee.svg
 maintainers:
   - name: unique-ag
     url: https://unique.ch/
 name: sscsid-keeper
-version: 1.0.0
+sources:
+  - https://github.com/Unique-AG/helm-charts/tree/main/charts/sscsid-keeper
+version: 1.1.0
 description: |
   The SSCSID ([Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/)) Keeper (`sscsid-keeper`) is a chart that combines the often used `SecretProviderClass`, which is part of the SSCSID with a running deployment that mounts the matching secrets making them available to others within the same namespace.
 
-  This chart is a pet project of Unique to code more _DRY_ and not officially supported by the maintainers of the `Secrets Store CSI Driver`. Unique also prototypes new features, processes or ideas with this chart (e.g. chart signing). This chart is also not an official Helm chart of Unique AG and underlies no SLA or support even if used in production.
+  This chart is a pet project of Unique to code more _DRY_ and not officially supported by the maintainers of the `Secrets Store CSI Driver`. Unique also prototypes new features, processes or ideas with this chart (e.g. chart signing).
 
   Since Unique is at the time of writing Azure focused, leveraging the Azure managed AKS CSI Extension is sometimes simpler than manually installing other Secret _solutions_.
 
   Note that if you need more sophisticated features, or a officially maintained chart or option that supports reloading, ClusterSecrets etc, seek matching alternatives on your own behalf (e.g. [External Secrets Operator](https://external-secrets.io/latest/)).
+annotations:
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: Create and mount volumes correctly to the pod(s)
+    - kind: added
+      description: PodDisruptionBudget, enabled by default, can be disabled
+    - kind: added
+      description: Can specify the type of the secret object, defaults to Opaque

--- a/charts/sscsid-keeper/Chart.yaml
+++ b/charts/sscsid-keeper/Chart.yaml
@@ -19,8 +19,14 @@ description: |
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
+      description: spc.secrets[*].k8sSecretDataKey no longer hardcoded
+    - kind: fixed
       description: Create and mount volumes correctly to the pod(s)
     - kind: added
       description: PodDisruptionBudget, enabled by default, can be disabled
     - kind: added
       description: Can specify the type of the secret object, defaults to Opaque
+    - kind: changed
+      description: Secrets in spc are required and can not be empty, templating now fails if there are no secrets
+    - kind: changed
+      description: Chart is now officially supported by Unique AG

--- a/charts/sscsid-keeper/README.md
+++ b/charts/sscsid-keeper/README.md
@@ -1,33 +1,42 @@
 # sscsid-keeper
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-
 The SSCSID ([Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/)) Keeper (`sscsid-keeper`) is a chart that combines the often used `SecretProviderClass`, which is part of the SSCSID with a running deployment that mounts the matching secrets making them available to others within the same namespace.
 
-This chart is a pet project of Unique to code more _DRY_ and not officially supported by the maintainers of the `Secrets Store CSI Driver`. Unique also prototypes new features, processes or ideas with this chart (e.g. chart signing). This chart is also not an official Helm chart of Unique AG and underlies no SLA or support even if used in production.
+This chart is a pet project of Unique to code more _DRY_ and not officially supported by the maintainers of the `Secrets Store CSI Driver`. Unique also prototypes new features, processes or ideas with this chart (e.g. chart signing).
 
 Since Unique is at the time of writing Azure focused, leveraging the Azure managed AKS CSI Extension is sometimes simpler than manually installing other Secret _solutions_.
 
 Note that if you need more sophisticated features, or a officially maintained chart or option that supports reloading, ClusterSecrets etc, seek matching alternatives on your own behalf (e.g. [External Secrets Operator](https://external-secrets.io/latest/)).
 
-## Maintainers
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| unique-ag |  | <https://unique.ch/> |
+## Implementation Details
+
+### OCI availibility
+This chart is available both as Helm Repository as well as OCI artefact.
+```sh
+helm repo add unique https://unique-ag.github.io/helm-charts/
+helm install my-sscsid-keeper unique/sscsid-keeper --version 1.1.0
+
+# or
+helm install my-sscsid-keeper oci://ghcr.io/unique-ag/helm-charts/sscsid-keeper --version 1.1.0
+```
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` | This is to override the full name. |
-| keeper | object | `{"affinity":{},"image":{"pullPolicy":"IfNotPresent","repository":"busybox","tag":"1.37.0"},"imagePullSecrets":[],"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"replicaCount":2,"resourcesPreset":"yocto","securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true},"tolerations":[]}` | Set options for the deployed keeper, its deployment and pods respectively. |
+| keeper | object | `{"affinity":{},"image":{"pullPolicy":"IfNotPresent","repository":"busybox","tag":"1.37.0"},"imagePullSecrets":[],"pdb":{"enabled":true,"minAvailable":1},"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"replicaCount":2,"resourcesPreset":"yocto","securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true},"tolerations":[]}` | Set options for the deployed keeper, its deployment and pods respectively. |
 | keeper.affinity | object | `{}` | Default affinity preset for the keeper |
 | keeper.image | object | `{"pullPolicy":"IfNotPresent","repository":"busybox","tag":"1.37.0"}` | This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/ |
 | keeper.image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | keeper.image.repository | string | `"busybox"` | This sets the image repository. |
 | keeper.image.tag | string | `"1.37.0"` | Overrides the image tag whose default is the chart appVersion. |
 | keeper.imagePullSecrets | list | `[]` | This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| keeper.pdb | object | `{"enabled":true,"minAvailable":1}` | Set the PodDisruptionBudget for the keeper |
+| keeper.pdb.enabled | bool | `true` | enabled by default as it keeps the secret |
+| keeper.pdb.minAvailable | int | `1` | defines how many pods should be kept around, half of the replica in our example |
 | keeper.podAnnotations | object | `{}` | This is for setting Kubernetes Annotations to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ |
 | keeper.podLabels | object | `{}` | This is for setting Kubernetes Labels to a Pod. For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ |
 | keeper.podSecurityContext | object | `{}` | Toggle and define pod-level security context. |
@@ -36,10 +45,13 @@ Note that if you need more sophisticated features, or a officially maintained ch
 | keeper.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true}` | Toggle and define security context. |
 | keeper.tolerations | list | `[]` | Tolerations for the keeper |
 | nameOverride | string | `""` | This is to override the release name. |
-| spc | object | `{"identityId":"00000000-0000-0000-0000-000000000000","kvName":"keyvault-name","secrets":[],"tenantId":"00000000-0000-0000-0000-000000000000"}` | Set options for the Secret Provider Class |
+| spc | object | `{"identityId":"00000000-0000-0000-0000-000000000000","k8sSecretType":"Opaque","kvName":"keyvault-name","secrets":[{"k8sSecretDataKey":"apiKeyExample","kvObjectName":"my-special-example-key"}],"tenantId":"00000000-0000-0000-0000-000000000000"}` | Set options for the Secret Provider Class |
 | spc.identityId | string | `"00000000-0000-0000-0000-000000000000"` | Azure Entra ID Identity Client ID |
+| spc.k8sSecretType | string | `"Opaque"` | Type of Kubernetes Secret |
 | spc.kvName | string | `"keyvault-name"` | Azure KeyVault which stores the secrets, must be available over the network |
-| spc.secrets | list | `[]` | Set the secret objects for the Secret Provider Class |
+| spc.secrets | list | `[{"k8sSecretDataKey":"apiKeyExample","kvObjectName":"my-special-example-key"}]` | Set the secret objects for the Secret Provider Class |
+| spc.secrets[0].k8sSecretDataKey | string | `"apiKeyExample"` | defines, which key in the secret object should be used |
+| spc.secrets[0].kvObjectName | string | `"my-special-example-key"` | defines, which object from the Key Vault should be used |
 | spc.tenantId | string | `"00000000-0000-0000-0000-000000000000"` | Azure Entra ID Tenant ID wherein the Managed Identity is present |
 
 ----------------------------------------------

--- a/charts/sscsid-keeper/README.md.gotmpl
+++ b/charts/sscsid-keeper/README.md.gotmpl
@@ -1,0 +1,22 @@
+{{ template "chart.header" . }}
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Implementation Details
+
+### OCI availibility
+This chart is available both as Helm Repository as well as OCI artefact.
+```sh
+helm repo add unique https://unique-ag.github.io/helm-charts/
+helm install my-{{ template "chart.name" . }} unique/{{ template "chart.name" . }} --version {{ template "chart.version" . }}
+
+# or
+helm install my-{{ template "chart.name" . }} oci://ghcr.io/unique-ag/helm-charts/{{ template "chart.name" . }} --version {{ template "chart.version" . }}
+```
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/sscsid-keeper/templates/_sscsi.tpl
+++ b/charts/sscsid-keeper/templates/_sscsi.tpl
@@ -10,7 +10,7 @@ array:
 {{- define "renderData" -}}
 data:
   {{- range . }}
-  - key: APISecret
+  - key: {{ .k8sSecretDataKey }}
     objectName: {{ .kvObjectName }}
   {{- end -}}
 {{- end -}}

--- a/charts/sscsid-keeper/templates/deployment.yaml
+++ b/charts/sscsid-keeper/templates/deployment.yaml
@@ -45,6 +45,17 @@ spec:
           {{- else if ne .Values.keeper.resourcesPreset "none" }}
           resources: {{- include "resources.preset" (dict "type" .Values.keeper.resourcesPreset) | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - mountPath: /mnt/spc
+              name: {{ include "sscsid-keeper.fullname" . }}
+              readOnly: true
+      volumes:
+        - csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "sscsid-keeper.fullname" . }}
+          name: {{ include "sscsid-keeper.fullname" . }}
       {{- with .Values.keeper.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/sscsid-keeper/templates/pod-disruption-budget.yaml
+++ b/charts/sscsid-keeper/templates/pod-disruption-budget.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.keeper.pdb.enabled (gt (int .Values.keeper.replicaCount) 1) }}
+{{- if le (int .Values.keeper.replicaCount) (int (default 1 .Values.keeper.pdb.minAvailable)) }}
+{{- fail "replicaCount must be greater than minAvailable." }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "sscsid-keeper.fullname" . }}
+  labels:
+    {{- include "sscsid-keeper.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.keeper.pdb.minAvailable | default 1}}
+  selector:
+    matchLabels:
+    {{- include "sscsid-keeper.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/sscsid-keeper/templates/secret-provider-class.yaml
+++ b/charts/sscsid-keeper/templates/secret-provider-class.yaml
@@ -1,3 +1,8 @@
+{{- $fullName := include "sscsid-keeper.fullname" . -}}
+{{- $k8sSecretType := .Values.spc.k8sSecretType -}}
+{{- if (lt (len .Values.spc.secrets) 1) }}
+{{- fail "spc.secrets list is required and cannot be empty. Using this chart without a secret makes no sense ;)" }}
+{{- end }}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
@@ -6,8 +11,8 @@ spec:
   provider: azure
   secretObjects:
     {{- range .Values.spc.secrets }}
-    - secretName: {{ .k8sSecretDataKey }}
-      type: Opaque
+    - secretName: {{ $fullName }}
+      type: {{ $k8sSecretType }}
       {{- include "renderData" (list .) | nindent 6 }}
     {{- end }}
   parameters:

--- a/charts/sscsid-keeper/tests/deployment._test.yaml
+++ b/charts/sscsid-keeper/tests/deployment._test.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test Deployment
+templates:
+  - deployment.yaml
+release:
+  name: ut
+tests:
+  - it: When given a SecretProviderClass, renders volumes and volumeMounts     
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - exists:
+          path: spec.template.spec.volumes[?(@.name == "ut-sscsid-keeper")]
+      - exists:
+          path: spec.template.spec.volumes[?(@.name == "ut-sscsid-keeper")].csi.volumeAttributes.secretProviderClass
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "ut-sscsid-keeper")].csi.volumeAttributes.secretProviderClass
+          value: ut-sscsid-keeper
+      - exists:
+          path: spec.template.spec.containers[?(@.name == "sscsid-keeper")].volumeMounts[?(@.mountPath == "/mnt/spc")]
+      - exists:
+          path: spec.template.spec.containers[?(@.name == "sscsid-keeper")].volumeMounts[?(@.name == "ut-sscsid-keeper")]

--- a/charts/sscsid-keeper/tests/readme.md
+++ b/charts/sscsid-keeper/tests/readme.md
@@ -1,0 +1,15 @@
+## `sscsid-keeper` Unit Tests
+Tests are written using [`helm-unittest`](https://github.com/helm-unittest/helm-unittest).
+
+### Install
+You need to install `helm-unittest` to run the tests. Refer to the [official docs](https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#install) for installation instructions.
+
+### Run
+```bash
+# charts/sscsid-keeper
+helm unittest .
+helm unittest . -d # to debug failing tests
+```
+
+### `__snapshot__`
+If we ever want to use `__snapshot__` we must remove the local `.gitignore`.

--- a/charts/sscsid-keeper/tests/secret-provider-class._test.yaml
+++ b/charts/sscsid-keeper/tests/secret-provider-class._test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test SecretProviderClass
+templates:
+  - secret-provider-class.yaml
+release:
+  name: ut
+tests:
+  - it: When given a list of secrets, renders secretObjects containing at least 1 key
+    set:
+      spc:
+        secrets:
+          - k8sSecretDataKey: keyTestUt
+            kvObjectName: my-api-key
+        
+    template: secret-provider-class.yaml
+    asserts:
+      - isKind:
+          of: SecretProviderClass
+      - exists:
+          path: spec.secretObjects[?(@.secretName == "ut-sscsid-keeper")]
+      - exists:
+          path: spec.secretObjects[?(@.secretName == "ut-sscsid-keeper")].data[?(@.key == "keyTestUt")]
+
+  - it: When given a new secret type, renders such (kubernetes.io/dockerconfigjson)
+    set:
+      spc:
+        k8sSecretType: kubernetes.io/dockerconfigjson
+        secrets:
+          - k8sSecretDataKey: .dockerconfigjson
+            kvObjectName: my-own-dockerconfig
+        
+    template: secret-provider-class.yaml
+    asserts:
+      - isKind:
+          of: SecretProviderClass
+      - exists:
+          path: spec.secretObjects[?(@.secretName == "ut-sscsid-keeper")]
+      - exists:
+          path: spec.secretObjects[?(@.type == "kubernetes.io/dockerconfigjson")]
+      - exists:
+          path: spec.secretObjects[?(@.secretName == "ut-sscsid-keeper")].data[?(@.key == ".dockerconfigjson")]

--- a/charts/sscsid-keeper/values.yaml
+++ b/charts/sscsid-keeper/values.yaml
@@ -38,7 +38,8 @@ keeper:
 
   # -- Toggle and define pod-level security context.
   # @default -- `{}`
-  podSecurityContext: {}
+  podSecurityContext:
+    {}
     # fsGroup: 2000
 
   # -- Toggle and define security context.
@@ -46,7 +47,7 @@ keeper:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: true
     runAsNonRoot: true
 
@@ -58,12 +59,12 @@ keeper:
   # -- Set container requests and limits for different resources like CPU or memory (essential for production workloads)
   # resources: {}
   # @ignored
-    # limits:
-    #   cpu: 100m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 128Mi
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
   # -- Node Selector for the keeper
   nodeSelector: {}
 
@@ -82,7 +83,6 @@ keeper:
 
 # -- Set options for the Secret Provider Class
 spc:
-
   # -- Azure KeyVault which stores the secrets, must be available over the network
   kvName: "keyvault-name"
 
@@ -91,14 +91,13 @@ spc:
 
   # -- Azure Entra ID Identity Client ID
   identityId: "00000000-0000-0000-0000-000000000000"
-  
+
   # -- Type of Kubernetes Secret
   k8sSecretType: "Opaque"
 
   # -- Set the secret objects for the Secret Provider Class
   secrets:
-    - 
-      # -- defines, which key in the secret object should be used
+    - # -- defines, which key in the secret object should be used
       k8sSecretDataKey: apiKeyExample
       # -- defines, which object from the Key Vault should be used
       kvObjectName: my-special-example-key

--- a/charts/sscsid-keeper/values.yaml
+++ b/charts/sscsid-keeper/values.yaml
@@ -73,6 +73,13 @@ keeper:
   # -- Default affinity preset for the keeper
   affinity: {}
 
+  # -- Set the PodDisruptionBudget for the keeper
+  pdb:
+    # -- enabled by default as it keeps the secret
+    enabled: true
+    # -- defines how many pods should be kept around, half of the replica in our example
+    minAvailable: 1
+
 # -- Set options for the Secret Provider Class
 spc:
 
@@ -84,8 +91,14 @@ spc:
 
   # -- Azure Entra ID Identity Client ID
   identityId: "00000000-0000-0000-0000-000000000000"
+  
+  # -- Type of Kubernetes Secret
+  k8sSecretType: "Opaque"
 
   # -- Set the secret objects for the Secret Provider Class
-  secrets: []
-    # - k8sSecretDataKey: APISecret
-    #   kvObjectName: some-secret-in-kv
+  secrets:
+    - 
+      # -- defines, which key in the secret object should be used
+      k8sSecretDataKey: apiKeyExample
+      # -- defines, which object from the Key Vault should be used
+      kvObjectName: my-special-example-key


### PR DESCRIPTION
Prepares for the arrival of Uniques chart `image-pull-secret`.

This PR also enables `ct install` which test installs all charts on `pull_request `.