### PR TITLE
fix!: consistent naming and fix web-app to not hardcode the /

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: quality
+.PHONY: quality ct-install
 
 .DEFAULT_GOAL := quality
 
@@ -8,3 +8,6 @@ quality:
 	@./scripts/helm-docs.sh
 	@./scripts/lint.sh
 	@echo "Quality checks completed."
+
+ct-install:
+	@ct install --config .github/configs/ct-install.yaml

--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: backend-service
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/backend-service
-version: 2.0.1
+version: 3.0.0
 description: |
   The 'backend-service' chart is a "convenience" chart from Unique AG that can generically be used to deploy backend workloads to Kubernetes.
 
@@ -15,5 +15,7 @@ description: |
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "⚠️ Changes inconsistent naming where some used `lower_snake_case` and others `camelCase`. All values now use `camelCase`."
     - kind: changed
-      description: "Require `/` prefix for all routes paths"
+      description: "⚠️ The `routes.paths.up` path was changed to `routes.paths.probe` to align with the rest of the naming."

--- a/charts/backend-service/README.md
+++ b/charts/backend-service/README.md
@@ -4,7 +4,7 @@ The 'backend-service' chart is a "convenience" chart from Unique AG that can gen
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -12,10 +12,10 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 This chart is available both as Helm Repository as well as OCI artefact.
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-backend-service unique/backend-service --version 2.0.1
+helm install my-backend-service unique/backend-service --version 3.0.0
 
 # or
-helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 2.0.1
+helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 3.0.0
 ```
 
 ### Docker Images
@@ -127,16 +127,18 @@ You can find a `extraCronJobs` example in the [`ci/extra-cronjobs-values.yaml`](
 | resources | object | `{}` |  |
 | rollingUpdate.maxSurge | int | `1` |  |
 | rollingUpdate.maxUnavailable | int | `0` |  |
-| routes | object | `{"gateway":{"name":"kong","namespace":"system"},"hostname":"chart-testing-service.example.com","path_prefix":"","paths":{"default":{"block_list":["/metrics"],"enabled":false,"extraAnnotations":[]},"scoped":{"allow_list":["/upload"],"enabled":false,"extraAnnotations":[],"path_override":"/scoped"},"up":{"enabled":false,"extraAnnotations":[],"probe_path":"/probe"},"versioned":{"enabled":false,"extraAnnotations":[],"path_override":"/public","x_api_version":"2023-12-06"}}}` | routes is a special object designed for Unique services. It abstracts a lot of complexity and allows for a simple configuration of routes. ⚠️ Unique defaults to Kong as its API Gateway (the middlewares especially), and the routes object is designed to work with Kong (but might work with other implementations as well). If you are using a different API Gateway, you will need to change the `gateway details` or use `extraRoutes`. Refer to [`ci/routes-values.yaml`](https://github.com/Unique-AG/helm-charts/blob/main/charts/backend-service/ci/routes-values.yaml) to see a full example of how to configure routes. Currently, routes must be explicitly enabled until the Unique Kong migration is complete. |
+| routes | object | `{"gateway":{"name":"kong","namespace":"system"},"hostname":"chart-testing-service.example.com","pathPrefix":"","paths":{"default":{"blockList":["/metrics"],"enabled":false,"extraAnnotations":[]},"probe":{"enabled":false,"extraAnnotations":[],"probePath":"/probe"},"scoped":{"allowList":["/upload"],"enabled":false,"extraAnnotations":[],"pathOverride":"/scoped"},"versioned":{"enabled":false,"extraAnnotations":[],"pathOverride":"/public","xApiVersion":"2023-12-06"}}}` | routes is a special object designed for Unique services. It abstracts a lot of complexity and allows for a simple configuration of routes. ⚠️ Unique defaults to Kong as its API Gateway (the middlewares especially), and the routes object is designed to work with Kong (but might work with other implementations as well). If you are using a different API Gateway, you will need to change the `gateway details` or use `extraRoutes`. Refer to [`ci/routes-values.yaml`](https://github.com/Unique-AG/helm-charts/blob/main/charts/backend-service/ci/routes-values.yaml) to see a full example of how to configure routes. Currently, routes must be explicitly enabled until the Unique Kong migration is complete. |
 | routes.gateway | object | `{"name":"kong","namespace":"system"}` | gateway to use |
 | routes.gateway.name | string | kong | name of the gateway |
 | routes.gateway.namespace | string | system | namespace of the gateway |
-| routes.path_prefix | string | defaults to the fullname of the service | path_prefix allows setting the default prefix (fullname) for all paths |
-| routes.paths.scoped.allow_list | list | `["/upload"]` | explicitly list of exact path matches will be rendered to: `/{scoped|path_override}/{entry}` |
-| routes.paths.scoped.path_override | string | the chart will default to 'scoped' to stay backward compatible | users wishing to not call their scoped API 'scoped' can override the path ⚠️ Customizing this value requires also changing the default url in multiple places including all web-apps |
-| routes.paths.up | object | `{"enabled":false,"extraAnnotations":[],"probe_path":"/probe"}` | `/up` is unauthorized and its sole purpose is to expose a health check endpoint for availability monitoring Maps to version neutral `/probe` endpoint all Unique services expose |
-| routes.paths.versioned.path_override | string | the chart will default to 'public' to stay backward compatible | users wishing to not call their versioned API 'public' can override the path ⚠️ Customizing this value requires also changing the default url in multiple places including all SDK or integration use cases |
-| routes.paths.versioned.x_api_version | string | the chart will default to "2023-12-06" | specified version of the API to use |
+| routes.pathPrefix | string | defaults to /fullname of the service | pathPrefix allows setting the default prefix (fullname) for all paths |
+| routes.paths.default.blockList | list | `["/metrics"]` | explicitly list paths to block |
+| routes.paths.probe | object | `{"enabled":false,"extraAnnotations":[],"probePath":"/probe"}` | `/probe` is unauthorized and its sole purpose is to expose a health check endpoint for availability monitoring Maps to version neutral `/probe` endpoint all Unique services expose |
+| routes.paths.probe.probePath | string | `"/probe"` | path to the probe endpoint |
+| routes.paths.scoped.allowList | list | `["/upload"]` | explicitly list of exact path matches will be rendered to: `/{scoped|pathOverride}/{entry}` |
+| routes.paths.scoped.pathOverride | string | the chart will default to 'scoped' to stay backward compatible | users wishing to not call their scoped API 'scoped' can override the path ⚠️ Customizing this value requires also changing the default url in multiple places including all web-apps |
+| routes.paths.versioned.pathOverride | string | the chart will default to 'public' to stay backward compatible | users wishing to not call their versioned API 'public' can override the path ⚠️ Customizing this value requires also changing the default url in multiple places including all SDK or integration use cases |
+| routes.paths.versioned.xApiVersion | string | the chart will default to "2023-12-06" | specified version of the API to use |
 | secretProvider | object | `{}` |  |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | SecurityContext for the container(s) |
 | securityContext.allowPrivilegeEscalation | bool | `false` | AllowPrivilegeEscalation, controls if the container can gain more privileges than its parent process, defaults to 'false' |

--- a/charts/backend-service/README.md
+++ b/charts/backend-service/README.md
@@ -160,6 +160,11 @@ You can find a `extraCronJobs` example in the [`ci/extra-cronjobs-values.yaml`](
 
 ## Upgrade Guides
 
+### ~> 3.0.0
+
+- `routes` uses `camelCase` for its keys, replace all `lower_snake_case` keys with `camelCase`
+- `routes.paths.up` is renamed to `routes.paths.probe`, update your `routes` accordingly
+
 ### ~> 2.0.0
 
 - `httproute` is converted into a dictionary and moves into `extraRoutes`

--- a/charts/backend-service/README.md.gotmpl
+++ b/charts/backend-service/README.md.gotmpl
@@ -50,6 +50,11 @@ You can find a `extraCronJobs` example in the [`ci/extra-cronjobs-values.yaml`](
 
 ## Upgrade Guides
 
+### ~> 3.0.0
+
+- `routes` uses `camelCase` for its keys, replace all `lower_snake_case` keys with `camelCase`
+- `routes.paths.up` is renamed to `routes.paths.probe`, update your `routes` accordingly
+
 ### ~> 2.0.0
 
 - `httproute` is converted into a dictionary and moves into `extraRoutes`

--- a/charts/backend-service/ci/routes-values.yaml
+++ b/charts/backend-service/ci/routes-values.yaml
@@ -14,13 +14,13 @@ routes:
     # -- namespace of the gateway
     # @default -- system
     namespace: system
-  # -- path_prefix allows setting the default prefix (fullname) for all paths
+  # -- pathPrefix allows setting the default prefix (fullname) for all paths
   # @default -- defaults to the fullname of the service
-  path_prefix: ""
+  pathPrefix: ""
   paths:
     default:
       enabled: true
-      block_list:
+      blockList:
         - /metrics
       extraAnnotations: []
       #   konghq.com/request-buffering: "false"
@@ -29,11 +29,11 @@ routes:
       enabled: true
       # -- specified version of the API to use
       # @default -- the chart will default to "2023-12-06"
-      x_api_version: "2023-12-06"
+      xApiVersion: "2023-12-06"
       # -- users wishing to not call their versioned API 'public' can override the path
       # ⚠️ Customizing this value requires also changing the default url in multiple places including all SDK or integration use cases
       # @default -- the chart will default to 'public' to stay backward compatible
-      path_override: /public
+      pathOverride: /public
       extraAnnotations: []
       #   konghq.com/request-buffering: "false"
     scoped:
@@ -41,16 +41,16 @@ routes:
       # -- users wishing to not call their scoped API 'scoped' can override the path
       # ⚠️ Customizing this value requires also changing the default url in multiple places including all web-apps
       # @default -- the chart will default to 'scoped' to stay backward compatible
-      path_override: /scoped
+      pathOverride: /scoped
       # -- explicitly list of exact path matches
-      # will be rendered to: `/{scoped|path_override}/{entry}`
-      allow_list:
+      # will be rendered to: `/{scoped|pathOverride}/{entry}`
+      allowList:
         - /upload
       extraAnnotations: []
       #   konghq.com/request-buffering: "false"
-    # -- `/up` is unauthorized and its sole purpose is to expose a health check endpoint for availability monitoring
+    # -- `/probe` is unauthorized and its sole purpose is to expose a health check endpoint for availability monitoring
     # Maps to version neutral `/probe` endpoint all Unique services expose
-    up:
+    probe:
       enabled: true
       extraAnnotations: []
       #   konghq.com/strip-path: "true"

--- a/charts/backend-service/templates/_helpers.tpl
+++ b/charts/backend-service/templates/_helpers.tpl
@@ -72,8 +72,8 @@ app.kubernetes.io/component: hooks-db-migration
 
 {{/* Helper to get the prefix */}}
 {{- define "backendService.routePrefix" -}}
-{{- if .Values.routes.path_prefix -}}
-{{- .Values.routes.path_prefix -}}
+{{- if .Values.routes.pathPrefix -}}
+{{- .Values.routes.pathPrefix -}}
 {{- else -}}
 /{{- include "backendService.fullname" . -}}
 {{- end -}}

--- a/charts/backend-service/templates/routes.yaml
+++ b/charts/backend-service/templates/routes.yaml
@@ -38,8 +38,8 @@ spec:
 
 {{/* Block list routes */}}
 {{/* Currently, the 'request-termination' plugin does not yet work well with 'extensionRefs' so we fall back to two paths for now */}}
-{{- if and .Values.routes.paths.default.enabled .Values.routes.paths.default.block_list }}
-{{- range .Values.routes.paths.default.block_list }}
+{{- if and .Values.routes.paths.default.enabled .Values.routes.paths.default.blockList }}
+{{- range .Values.routes.paths.default.blockList }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -103,16 +103,16 @@ spec:
           urlRewrite:
             path:
               type: ReplacePrefixMatch
-              replacePrefixMatch: {{ default "/public" .Values.routes.paths.versioned.path_override }}
+              replacePrefixMatch: {{ default "/public" .Values.routes.paths.versioned.pathOverride }}
         - type: RequestHeaderModifier
           requestHeaderModifier:
             add:
               - name: x-api-version
-                value: {{ default "2023-12-06" .Values.routes.paths.versioned.x_api_version | quote }}
+                value: {{ default "2023-12-06" .Values.routes.paths.versioned.xApiVersion | quote }}
       matches:
         - path:
             type: PathPrefix
-            value: {{ default "/public" .Values.routes.paths.versioned.path_override }}{{ include "backendService.routePrefix" $ }}
+            value: {{ default "/public" .Values.routes.paths.versioned.pathOverride }}{{ include "backendService.routePrefix" $ }}
 {{- end }}
 
 {{/* scoped route */}}
@@ -140,35 +140,35 @@ spec:
     - {{ tpl (.Values.routes.hostname) $ }}
   rules:
     - matches:
-      {{- range .Values.routes.paths.scoped.allow_list }}
+      {{- range .Values.routes.paths.scoped.allowList }}
         - path:
             type: PathPrefix
-            value: {{ default "/scoped" $.Values.routes.paths.scoped.path_override }}{{ . }}
+            value: {{ default "/scoped" $.Values.routes.paths.scoped.pathOverride }}{{ . }}
       {{- end }}
       filters:
         - type: URLRewrite
           urlRewrite:
             path:
               type: ReplacePrefixMatch
-              replacePrefixMatch: {{ default "/scoped" .Values.routes.paths.scoped.path_override }}
+              replacePrefixMatch: {{ default "/scoped" .Values.routes.paths.scoped.pathOverride }}
       backendRefs:
         - name: {{ include "backendService.fullname" $ }}
           port: {{ $.Values.service.port }}
           kind: Service
 {{- end }}
 
-{{/* up route */}}
-{{- if .Values.routes.paths.up.enabled -}}
+{{/* probe route */}}
+{{- if .Values.routes.paths.probe.enabled -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ template "backendService.fullname" $ }}-up
+  name: {{ template "backendService.fullname" $ }}-probe
   annotations:
     konghq.com/strip-path: "true"
     konghq.com/plugins: unique-route-metrics
-    {{- if .Values.routes.paths.up.extraAnnotations }}
-    {{- toYaml .Values.routes.paths.up.extraAnnotations | nindent 4 }}
+    {{- if .Values.routes.paths.probe.extraAnnotations }}
+    {{- toYaml .Values.routes.paths.probe.extraAnnotations | nindent 4 }}
     {{- end }}
   labels:
     {{- include "backendService.labels" $ | nindent 4 }}
@@ -184,14 +184,14 @@ spec:
     - matches:
         - path:
             type: Exact
-            value: {{ include "backendService.routePrefix" $ }}{{ default "/probe" .Values.routes.paths.up.probe_path }}
+            value: {{ include "backendService.routePrefix" $ }}{{ default "/probe" .Values.routes.paths.probe.probePath }}
             # TODO: Add https://docs.konghq.com/hub/kong-inc/response-transformer/ to omit the response body
       filters:
         - type: URLRewrite
           urlRewrite:
             path:
               type: ReplaceFullPath
-              replaceFullPath: {{ default "/probe" .Values.routes.paths.up.probe_path }}
+              replaceFullPath: {{ default "/probe" .Values.routes.paths.probe.probePath }}
       backendRefs:
         - name: {{ include "backendService.fullname" $ }}
           port: {{ $.Values.service.port }}
@@ -199,5 +199,5 @@ spec:
 {{- end }}
 
 {{- else }}
-{{- fail "You can't use routes without CRDs installed. Install CRDs first."}}
+{{- fail "You can't use routes without gateway.networking.k8s.io CRDs installed. Install CRDs first."}}
 {{- end }}

--- a/charts/backend-service/values.yaml
+++ b/charts/backend-service/values.yaml
@@ -358,13 +358,14 @@ routes:
     # -- namespace of the gateway
     # @default -- system
     namespace: system
-  # -- path_prefix allows setting the default prefix (fullname) for all paths
-  # @default -- defaults to the fullname of the service
-  path_prefix: ""
+  # -- pathPrefix allows setting the default prefix (fullname) for all paths
+  # @default -- defaults to /fullname of the service
+  pathPrefix: ""
   paths:
     default:
       enabled: false
-      block_list:
+      # -- explicitly list paths to block
+      blockList:
         - /metrics
       extraAnnotations: []
         # konghq.com/request-buffering: "false"
@@ -373,11 +374,11 @@ routes:
       enabled: false
       # -- specified version of the API to use
       # @default -- the chart will default to "2023-12-06"
-      x_api_version: "2023-12-06"
+      xApiVersion: "2023-12-06"
       # -- users wishing to not call their versioned API 'public' can override the path
       # ⚠️ Customizing this value requires also changing the default url in multiple places including all SDK or integration use cases
       # @default -- the chart will default to 'public' to stay backward compatible
-      path_override: /public
+      pathOverride: /public
       extraAnnotations: []
         # konghq.com/request-buffering: "false"
     scoped:
@@ -385,18 +386,19 @@ routes:
       # -- users wishing to not call their scoped API 'scoped' can override the path
       # ⚠️ Customizing this value requires also changing the default url in multiple places including all web-apps
       # @default -- the chart will default to 'scoped' to stay backward compatible
-      path_override: /scoped
+      pathOverride: /scoped
       # -- explicitly list of exact path matches
-      # will be rendered to: `/{scoped|path_override}/{entry}`
-      allow_list:
+      # will be rendered to: `/{scoped|pathOverride}/{entry}`
+      allowList:
         - /upload
       extraAnnotations: []
       #   konghq.com/request-buffering: "false"
-    # -- `/up` is unauthorized and its sole purpose is to expose a health check endpoint for availability monitoring
+    # -- `/probe` is unauthorized and its sole purpose is to expose a health check endpoint for availability monitoring
     # Maps to version neutral `/probe` endpoint all Unique services expose
-    up:
+    probe:
       enabled: false
-      probe_path: /probe
+      # -- path to the probe endpoint
+      probePath: /probe
       extraAnnotations: []
         # konghq.com/strip-path: "true"
 

--- a/charts/web-app/Chart.yaml
+++ b/charts/web-app/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: unique-ag
     url: https://unique.ch/
 name: web-app
-version: 2.0.1
+version: 3.0.0
 description: |
   The 'web-app' chart is a "convenience" chart from Unique AG that can generically be used to deploy web-content serving workloads to Kubernetes.
 
@@ -14,5 +14,7 @@ sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/web-app
 annotations:
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "⚠️ Changes inconsistent naming where some used `lower_snake_case` and others `camelCase`. All values now use `camelCase`."
     - kind: changed
-      description: "Removed `konghq.com/strip-path: true` from routes"
+      description: "⚠️ `routes.paths` and their sub-paths now use `/` as a prefix by default to increase consistency and understanding."

--- a/charts/web-app/README.md
+++ b/charts/web-app/README.md
@@ -4,7 +4,7 @@ The 'web-app' chart is a "convenience" chart from Unique AG that can generically
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -12,10 +12,10 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 This chart is available both as Helm Repository as well as OCI artefact.
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-web-app unique/web-app --version 2.0.1
+helm install my-web-app unique/web-app --version 3.0.0
 
 # or
-helm install my-web-app oci://ghcr.io/unique-ag/helm-charts/web-app --version 2.0.1
+helm install my-web-app oci://ghcr.io/unique-ag/helm-charts/web-app --version 3.0.0
 ```
 
 ### Docker Images
@@ -85,15 +85,15 @@ The Root Ingress is a convenience ingress that routes all traffic from the root 
 | resources | object | `{}` |  |
 | rollingUpdate.maxSurge | int | `1` |  |
 | rollingUpdate.maxUnavailable | int | `0` |  |
-| routes | object | `{"gateway":{"name":"kong","namespace":"system"},"hostname":"chart-testing-web-app.example.com","path_prefix":"","paths":{"default":{"block_list":["metrics"],"enabled":true},"root":{"enabled":false,"redirect_path":"chat"}}}` | routes is a special object designed for Unique web-apps. It abstracts a lot of complexity and allows for a simple configuration of routes. ⚠️ Unique defaults to Kong as its API Gateway (the middlewares especially), and the routes object is designed to work with Kong. If you are using a different API Gateway, you will need to use `extraRoutes`. |
+| routes | object | `{"gateway":{"name":"kong","namespace":"system"},"hostname":"chart-testing-web-app.example.com","pathPrefix":"","paths":{"default":{"blockList":["/metrics"],"enabled":true,"extraAnnotations":[]},"root":{"enabled":false,"redirectPath":"/chart-testing"}}}` | routes is a special object designed for Unique web-apps. It abstracts a lot of complexity and allows for a simple configuration of routes. ⚠️ Unique defaults to Kong as its API Gateway (the middlewares especially), and the routes object is designed to work with Kong. If you are using a different API Gateway, you will need to use `extraRoutes`. |
 | routes.gateway | object | `{"name":"kong","namespace":"system"}` | gateway to use |
 | routes.gateway.name | string | kong | name of the gateway |
 | routes.gateway.namespace | string | system | namespace of the gateway |
-| routes.path_prefix | string | defaults to the fullname of the service | path_prefix allows setting the default prefix (fullname) for all paths |
-| routes.paths.default | object | defaults to the fullname of the service | path_prefix allows overriding the default prefix (fullname) for all paths |
-| routes.paths.root | object | `{"enabled":false,"redirect_path":"chat"}` | The root route is a convenience route that routes all traffic from the root of the domain to a specific path ⚠️ The root route should only be activated once when multiple web-apps are deployed to the same cluster |
+| routes.pathPrefix | string | defaults to the /fullname of the service | pathPrefix allows setting the default prefix (fullname) for all paths |
+| routes.paths.default.blockList | list | `["/metrics"]` | explicitly list paths to block |
+| routes.paths.root | object | `{"enabled":false,"redirectPath":"/chart-testing"}` | The root route is a convenience route that routes all traffic from the root of the domain to a specific path ⚠️ The root route should only be activated once when multiple web-apps are deployed to the same cluster |
 | routes.paths.root.enabled | bool | `false` | Whether the root route should be enabled |
-| routes.paths.root.redirect_path | string | `"chat"` | The path to which the root should be redirected to |
+| routes.paths.root.redirectPath | string | defaults to the `pathPrefix` if enabled and omitted | The path to which the root should be redirected to ⚠️ This value must be a valid full path, not only the sub-path. A 302 redirect will be issued to this path (using full path replacement). |
 | secretProvider | object | `{}` |  |
 | securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | securityContext.runAsNonRoot | bool | `true` |  |

--- a/charts/web-app/README.md
+++ b/charts/web-app/README.md
@@ -109,6 +109,11 @@ The Root Ingress is a convenience ingress that routes all traffic from the root 
 
 ## Upgrade Guides
 
+### ~> 3.0.0
+
+- `routes` uses `camelCase` for its keys, replace all `lower_snake_case` keys with `camelCase`
+- `routes.paths` and their sub-paths no longer use `/` as a prefix by default, add it to your `routes`
+
 ### ~> 2.0.0
 
 - `httproute` is converted into a dictionary and moves into `extraRoutes`

--- a/charts/web-app/README.md.gotmpl
+++ b/charts/web-app/README.md.gotmpl
@@ -43,6 +43,11 @@ The Root Ingress is a convenience ingress that routes all traffic from the root 
 
 ## Upgrade Guides
 
+### ~> 3.0.0
+
+- `routes` uses `camelCase` for its keys, replace all `lower_snake_case` keys with `camelCase`
+- `routes.paths` and their sub-paths no longer use `/` as a prefix by default, add it to your `routes`
+
 ### ~> 2.0.0
 
 - `httproute` is converted into a dictionary and moves into `extraRoutes`

--- a/charts/web-app/ci/routes-values.yaml
+++ b/charts/web-app/ci/routes-values.yaml
@@ -14,14 +14,14 @@ routes:
     # -- namespace of the gateway
     # @default -- system
     namespace: system
-  # -- path_prefix allows setting the default prefix (fullname) for all paths
+  # -- pathPrefix allows setting the default prefix (fullname) for all paths
   # @default -- defaults to the fullname of the service
-  path_prefix: ""
+  pathPrefix: /my-service-ci
   paths:
     default:
       enabled: true
-      block_list:
-        - metrics
+      blockList:
+        - /metrics
       extraAnnotations: []
       #   konghq.com/request-buffering: "false"
       #   konghq.com/read-timeout: "120s"
@@ -29,4 +29,4 @@ routes:
       # -- Whether the root route should be enabled
       enabled: true
       # -- The path to which the root should be redirected to
-      redirect_path: chat
+      redirectPath: /my-service-ci

--- a/charts/web-app/templates/_helpers.tpl
+++ b/charts/web-app/templates/_helpers.tpl
@@ -58,11 +58,10 @@ Create the name of the service account to use
 {{- end }}
 
 {{/* Helper to get the prefix */}}
-{{- $fullName := include "common.fullname" . -}}
 {{- define "webApp.routePrefix" -}}
-{{- if .Values.routes.prefix_override -}}
-{{- .Values.routes.prefix_override -}}
+{{- if .Values.routes.pathPrefix -}}
+{{- .Values.routes.pathPrefix -}}
 {{- else -}}
-{{- include "common.fullname" . -}}
+/{{- include "common.fullname" . -}}
 {{- end -}}
 {{- end -}}

--- a/charts/web-app/templates/routes.yaml
+++ b/charts/web-app/templates/routes.yaml
@@ -32,7 +32,7 @@ spec:
       matches:
         - path:
             type: PathPrefix
-            value: /{{ include "webApp.routePrefix" $ }}
+            value: {{ include "webApp.routePrefix" $ }}
 {{- end }}
 
 {{/* Root route */}}
@@ -67,11 +67,11 @@ spec:
             hostname: {{ tpl ($.Values.routes.hostname) $ }}
             path:
               type: ReplaceFullPath
-              replaceFullPath: /{{ .Values.routes.paths.root.redirect_path }}
+              replaceFullPath: {{ default (include "webApp.routePrefix" $) .Values.routes.paths.root.redirectPath }}
             statusCode: 302 # Temporary Redirect, as we might change the root path in the future
             port: 443
 {{- end }}
 
 {{- else }}
-{{- fail "You can't use routes without CRDs installed. Install CRDs first."}}
+{{- fail "You can't use routes without gateway.networking.k8s.io CRDs installed. Install CRDs first."}}
 {{- end }}

--- a/charts/web-app/values.yaml
+++ b/charts/web-app/values.yaml
@@ -117,17 +117,16 @@ routes:
     # -- namespace of the gateway
     # @default -- system
     namespace: system
-  # -- path_prefix allows setting the default prefix (fullname) for all paths
-  # @default -- defaults to the fullname of the service
-  path_prefix: ""
+  # -- pathPrefix allows setting the default prefix (fullname) for all paths
+  # @default -- defaults to the /fullname of the service
+  pathPrefix: ""
   paths:
-    # -- path_prefix allows overriding the default prefix (fullname) for all paths
-    # @default -- defaults to the fullname of the service
     default:
       enabled: true
-      block_list:
-        - metrics
-      # extraAnnotations:
+      # -- explicitly list paths to block
+      blockList:
+        - /metrics
+      extraAnnotations: []
       #   konghq.com/request-buffering: "false"
       #   konghq.com/read-timeout: "120s"
     # -- The root route is a convenience route that routes all traffic from the root of the domain to a specific path
@@ -136,7 +135,9 @@ routes:
       # -- Whether the root route should be enabled
       enabled: false
       # -- The path to which the root should be redirected to
-      redirect_path: chat
+      # ⚠️ This value must be a valid full path, not only the sub-path. A 302 redirect will be issued to this path (using full path replacement).
+      # @default -- defaults to the `pathPrefix` if enabled and omitted
+      redirectPath: /chart-testing
 
 # -- BETA: Configure additional gateway routes for the chart here.
 # More routes can be added by adding a dictionary key like the 'extra-route-1' route.


### PR DESCRIPTION
- removes hardcoded `/` in `web-app`
- fixes bug where `prefix` wouldn't work in `web-app`
- improves documentation