### PR TITLE
fix(bs): fix blockList routes metadata double dashes

### DIFF
--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: backend-service
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/backend-service
-version: 3.0.1
+version: 3.0.2
 description: |
   The 'backend-service' chart is a "convenience" chart from Unique AG that can generically be used to deploy backend workloads to Kubernetes.
 
@@ -15,5 +15,5 @@ description: |
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Routes no longer redirect to HTTPS by default. This redirect must be handled in the upstream services or extended via extraAnnotations."
+    - kind: fixed
+      description: "Fixed an issue where blockList HTTPRoutes metadata name falsely included double dashes."

--- a/charts/backend-service/README.md
+++ b/charts/backend-service/README.md
@@ -4,7 +4,7 @@ The 'backend-service' chart is a "convenience" chart from Unique AG that can gen
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -12,10 +12,10 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 This chart is available both as Helm Repository as well as OCI artefact.
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-backend-service unique/backend-service --version 3.0.1
+helm install my-backend-service unique/backend-service --version 3.0.2
 
 # or
-helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 3.0.1
+helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 3.0.2
 ```
 
 ### Docker Images

--- a/charts/backend-service/templates/routes.yaml
+++ b/charts/backend-service/templates/routes.yaml
@@ -42,7 +42,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ template "backendService.fullname" $ }}-block-{{ . | replace "/" "-" }}
+  name: {{ template "backendService.fullname" $ }}-block{{ . | replace "/" "-" }}
   annotations:
     konghq.com/plugins: unique-block-route,unique-route-metrics
   labels:


### PR DESCRIPTION
This PR fixes an issue with the metadata name for the blockList HTTPRoutes including double dashes. The routes e.g.: `/metrics` start with a `/` that was then replaced with a `-`, which ended up being one too many together with the one that was hardcoded in the template.