### PR TITLE
fix(backend-service): multiple extraRoutes collapse onto previous line

### DIFF
--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: backend-service
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/backend-service
-version: 3.0.5
+version: 3.0.6
 description: |
   The 'backend-service' chart is a "convenience" chart from Unique AG that can generically be used to deploy backend workloads to Kubernetes.
 
@@ -16,4 +16,4 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: fixed
-      description: "Bug in routes.paths.default where when using / as pathPrefix would render invalid block list items with //."
+      description: "Bug where extraRoutes would be rendered invalid when given two or more routes (--- collapsed onto previous line)."

--- a/charts/backend-service/README.md
+++ b/charts/backend-service/README.md
@@ -4,7 +4,7 @@ The 'backend-service' chart is a "convenience" chart from Unique AG that can gen
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 3.0.5](https://img.shields.io/badge/Version-3.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.0.6](https://img.shields.io/badge/Version-3.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -12,10 +12,10 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 This chart is available both as Helm Repository as well as OCI artefact.
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-backend-service unique/backend-service --version 3.0.5
+helm install my-backend-service unique/backend-service --version 3.0.6
 
 # or
-helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 3.0.5
+helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 3.0.6
 ```
 
 ### Docker Images

--- a/charts/backend-service/ci/extra-routes-values.yaml
+++ b/charts/backend-service/ci/extra-routes-values.yaml
@@ -6,9 +6,26 @@ extraRoutes:
         namespace: kong-system
         group: gateway.networking.k8s.io
         kind: Gateway
+    hostnames:
+      - my.api.example.com
     matches:
       - path:
           type: PathPrefix
           value: /extra-route-1
+    filters: []
+    additionalRules: []
+  extra-route-2:
+    enabled: true
+    parentRefs:
+      - name: kong
+        namespace: kong-system
+        group: gateway.networking.k8s.io
+        kind: Gateway
+    hostnames:
+      - my.api.example.com
+    matches:
+      - path:
+          type: PathPrefix
+          value: /extra-route-2
     filters: []
     additionalRules: []

--- a/charts/backend-service/ci/routes-values.yaml
+++ b/charts/backend-service/ci/routes-values.yaml
@@ -22,6 +22,7 @@ routes:
       enabled: true
       blockList:
         - /metrics
+        - /sensitive
       extraAnnotations: []
       #   konghq.com/request-buffering: "false"
       #   konghq.com/read-timeout: "120s"

--- a/charts/backend-service/templates/extra-routes.yaml
+++ b/charts/backend-service/templates/extra-routes.yaml
@@ -5,7 +5,7 @@
 {{/* SPDX-SnippetEnd */}}
 {{- if .Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1" }}
 {{- range $name, $route := .Values.extraRoutes }}
-  {{- if $route.enabled -}}
+  {{- if $route.enabled }}
 ---
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: {{ $route.kind | default "HTTPRoute" }}

--- a/charts/backend-service/tests/extra-routes._test.yaml
+++ b/charts/backend-service/tests/extra-routes._test.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test HTTPRoute
+templates:
+  - extra-routes.yaml
+release:
+  name: ecj
+tests:
+  - it: When given two extra routes, should split them correctly (regression)
+    values:
+      - ../ci/extra-routes-values.yaml
+    capabilities:
+      apiVersions:
+        - gateway.networking.k8s.io/v1
+    template: extra-routes.yaml
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/backend-service/tests/routes._test.yaml
+++ b/charts/backend-service/tests/routes._test.yaml
@@ -183,3 +183,11 @@ tests:
                 - name: ecj
                   port: 8080
                   kind: Service
+            - matches:
+                - path:
+                    type: PathPrefix
+                    value: /sensitive
+              backendRefs:
+                - name: ecj
+                  port: 8080
+                  kind: Service


### PR DESCRIPTION
Fixes 

```
          - path:
              type: PathPrefix
              value: /oauth2/serviceToken---
  apiVersion: gateway.networking.k8s.io/v1
  kind: HTTPRoute
  metadata:
    annotations:
      konghq.com/plug
```