### PR TITLE
fix(backend-service): always supersed the port that is manually declared

### DIFF
--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: backend-service
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/backend-service
-version: 3.1.0
+version: 3.1.1
 description: |
   The 'backend-service' chart is a "convenience" chart from Unique AG that can generically be used to deploy backend workloads to Kubernetes.
 
@@ -15,9 +15,5 @@ description: |
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
-    - kind: changed
-      description: "values.yaml is now sorted alphabetically for readability, flat above nested."
-    - kind: changed
-      description: "service.port defaults back to 80 as now the application port is used instead for the Unique service. This change is non-breaking because users had to already set a specific port for the service in order to run as non-root using the RuntimeDefault securityContext."
-    - kind: added
-      description: "ports object, allows specifying ports for the service and deployment/application."
+    - kind: fixed
+      description: "env.PORT is now correctly set to the application port in any case even when a manual env.PORT was declared."

--- a/charts/backend-service/README.md
+++ b/charts/backend-service/README.md
@@ -4,7 +4,7 @@ The 'backend-service' chart is a "convenience" chart from Unique AG that can gen
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.1.1](https://img.shields.io/badge/Version-3.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -12,10 +12,10 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 This chart is available both as Helm Repository as well as OCI artefact.
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-backend-service unique/backend-service --version 3.1.0
+helm install my-backend-service unique/backend-service --version 3.1.1
 
 # or
-helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 3.1.0
+helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 3.1.1
 ```
 
 ### Docker Images

--- a/charts/backend-service/templates/deployment-env.yaml
+++ b/charts/backend-service/templates/deployment-env.yaml
@@ -6,10 +6,9 @@ metadata:
   labels:
     {{- include "backendService.labels" . | nindent 4 }}
 data:
-  VERSION: "{{ .Values.image.tag }}"
-  {{- if .Values.service.enabled }}
-  PORT: {{ include "backendService.applicationPort" $ | quote }}
-  {{- end }}
   {{- range $key, $value := .Values.env }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+  {{/* Static values are added last so that they override the dynamic values (avoids regression and breaking changes) */}}
+  VERSION: "{{ .Values.image.tag }}"
+  PORT: {{ include "backendService.applicationPort" $ | quote }}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c7f4bce4-26ba-4818-a140-2af43bfd18cf)

CM:
![image](https://github.com/user-attachments/assets/5a777a2e-5450-4fe0-a667-74ea483651a6)


Avoids scenarios where helm does not throw during render but a PORT was manually declared (old practice).