### PR TITLE
feat(kong-plugins): add logic to send userId to validate API endpoint

### DIFF
--- a/charts/kong-plugins/Chart.yaml
+++ b/charts/kong-plugins/Chart.yaml
@@ -17,4 +17,4 @@ description: |
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: pass the user_id if present to the validate endpoint to allow for user scoped API tokens to harden security
+      description: "the app repo middleware/plugin now optionally accepts a user_id as header forwarded by Kong to scope an app to a specific user"

--- a/charts/kong-plugins/Chart.yaml
+++ b/charts/kong-plugins/Chart.yaml
@@ -17,6 +17,4 @@ description: |
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: helmignore tests and readme templates
-    - kind: changed
-      description: pass the user_id if present to the validate endpoint
+      description: pass the user_id if present to the validate endpoint to allow for user scoped API tokens to harden security

--- a/charts/kong-plugins/Chart.yaml
+++ b/charts/kong-plugins/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: unique-ag
     url: https://unique.ch/
 name: kong-plugins
-version: 1.0.2
+version: 1.0.3
 description: |
   The 'kong-plugins' chart provides a streamlined solution for deploying Kong plugins via ConfigMaps to be used with the Unique Software.
 
@@ -18,3 +18,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: helmignore tests and readme templates
+    - kind: changed
+      description: pass the user_id if present to the validate endpoint

--- a/charts/kong-plugins/Chart.yaml
+++ b/charts/kong-plugins/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: unique-ag
     url: https://unique.ch/
 name: kong-plugins
-version: 1.0.3
+version: 1.1.0
 description: |
   The 'kong-plugins' chart provides a streamlined solution for deploying Kong plugins via ConfigMaps to be used with the Unique Software.
 

--- a/charts/kong-plugins/README.md
+++ b/charts/kong-plugins/README.md
@@ -1,6 +1,6 @@
 # kong-plugins
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 The 'kong-plugins' chart provides a streamlined solution for deploying Kong plugins via ConfigMaps to be used with the Unique Software.
 

--- a/charts/kong-plugins/README.md
+++ b/charts/kong-plugins/README.md
@@ -1,6 +1,6 @@
 # kong-plugins
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 The 'kong-plugins' chart provides a streamlined solution for deploying Kong plugins via ConfigMaps to be used with the Unique Software.
 


### PR DESCRIPTION
Added logic to include user-id in the request sent to the validate endpoint for API key validation