### PR TITLE
fix(backend-service): allow terminationGracePeriodSeconds

### DIFF
--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: backend-service
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/backend-service
-version: 4.1.1
+version: 4.1.2
 description: |
   The 'backend-service' chart is a "convenience" chart from Unique AG that can generically be used to deploy backend workloads to Kubernetes.
 
@@ -16,4 +16,4 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: fixed
-      description: "Integer CPU requests/limits are now allowed (again)."
+      description: "terminationGracePeriodSeconds is now allowed (again)."

--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -17,3 +17,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: "terminationGracePeriodSeconds is now allowed (again)."
+    - kind: fixed
+      description: "Allow CPU requests/limits float values."

--- a/charts/backend-service/README.md
+++ b/charts/backend-service/README.md
@@ -4,7 +4,7 @@ The 'backend-service' chart is a "convenience" chart from Unique AG that can gen
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 4.1.1](https://img.shields.io/badge/Version-4.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.1.2](https://img.shields.io/badge/Version-4.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -12,10 +12,10 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 This chart is available both as Helm Repository as well as OCI artefact.
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-backend-service unique/backend-service --version 4.1.1
+helm install my-backend-service unique/backend-service --version 4.1.2
 
 # or
-helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 4.1.1
+helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 4.1.2
 ```
 
 ### Docker Images

--- a/charts/backend-service/ci/deployment-numeric-values.yaml
+++ b/charts/backend-service/ci/deployment-numeric-values.yaml
@@ -1,6 +1,7 @@
 image:
   repository: "ghcr.io/unique-ag/chart-testing-service"
   tag: "1.0.3"
+terminationGracePeriodSeconds: 30
 resources:
   limits:
     cpu: 1

--- a/charts/backend-service/values.schema.json
+++ b/charts/backend-service/values.schema.json
@@ -709,7 +709,7 @@
             "cpu": {
               "oneOf": [
                 { "type": "string" },
-                { "type": "integer", "minimum": 0 }
+                { "type": "number", "minimum": 0 }
               ],
               "description": "CPU limit",
               "examples": [2, "1000m"]
@@ -728,7 +728,7 @@
             "cpu": {
               "oneOf": [
                 { "type": "string" },
-                { "type": "integer", "minimum": 0 }
+                { "type": "number", "minimum": 0 }
               ],
               "description": "CPU request",
               "examples": [1, "100m"]

--- a/charts/backend-service/values.schema.json
+++ b/charts/backend-service/values.schema.json
@@ -901,6 +901,11 @@
         }
       }
     },
+    "terminationGracePeriodSeconds": {
+      "type": "integer",
+      "description": "Override the termination grace period seconds.",
+      "examples": [30, 900]
+    },
     "tolerations": {
       "type": "array",
       "description": "Tolerations for pod placement"

--- a/charts/web-app/Chart.yaml
+++ b/charts/web-app/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: unique-ag
     url: https://unique.ch/
 name: web-app
-version: 4.1.1
+version: 4.1.2
 description: |
   The 'web-app' chart is a "convenience" chart from Unique AG that can generically be used to deploy web-content serving workloads to Kubernetes.
 
@@ -15,6 +15,4 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "Integer CPU requests/limits are now allowed (again)."
-    - kind: fixed
-      description: "Default path extraAnnotations are now validated correctly as an object."
+      description: "Allow CPU requests/limits float values."

--- a/charts/web-app/README.md
+++ b/charts/web-app/README.md
@@ -4,7 +4,7 @@ The 'web-app' chart is a "convenience" chart from Unique AG that can generically
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 4.1.1](https://img.shields.io/badge/Version-4.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.1.2](https://img.shields.io/badge/Version-4.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -12,10 +12,10 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 This chart is available both as Helm Repository as well as OCI artefact.
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-web-app unique/web-app --version 4.1.1
+helm install my-web-app unique/web-app --version 4.1.2
 
 # or
-helm install my-web-app oci://ghcr.io/unique-ag/helm-charts/web-app --version 4.1.1
+helm install my-web-app oci://ghcr.io/unique-ag/helm-charts/web-app --version 4.1.2
 ```
 
 ### Docker Images

--- a/charts/web-app/values.schema.json
+++ b/charts/web-app/values.schema.json
@@ -335,7 +335,7 @@
             "cpu": {
               "oneOf": [
                 { "type": "string" },
-                { "type": "integer", "minimum": 0 }
+                { "type": "number", "minimum": 0 }
               ],
               "description": "CPU limit",
               "examples": [2, "1000m"]
@@ -354,7 +354,7 @@
             "cpu": {
               "oneOf": [
                 { "type": "string" },
-                { "type": "integer", "minimum": 0 }
+                { "type": "number", "minimum": 0 }
               ],
               "description": "CPU request",
               "examples": [1, "100m"]


### PR DESCRIPTION
```
Error: values don't meet the specifications of the schema(s) in the following chart(s): backend-service: - (root): Additional property terminationGracePeriodSeconds is not allowed
```