### PR TITLE
feat(Extra-CronJobs): Add support for configurable volumeMounts in extra-cronjobs template

### DIFF
--- a/charts/backend-service/templates/extra-cronjobs.yaml
+++ b/charts/backend-service/templates/extra-cronjobs.yaml
@@ -57,6 +57,9 @@ spec:
               resources:
                 {{- toYaml ($value.resources | default $globalValues.resources) | nindent 16 }}
               volumeMounts:
+              {{- with $globalValues.volumeMounts }}
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               {{- if $globalValues.secretProvider }}
               {{- range $k, $v := $globalValues.secretProvider.vaults }}
                 - name: {{ $fullName }}-{{ $k }}


### PR DESCRIPTION
This pull request introduces a small enhancement to the `charts/backend-service/templates/extra-cronjobs.yaml` file. The change adds support for dynamically including `volumeMounts` from `globalValues` when they are defined.