### PR TITLE
feat(chart): bump version to 4.5.0 and add audit volume mount support

### DIFF
--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
 name: backend-service
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/backend-service
-version: 4.4.0
+version: 4.5.0
 description: |
   The 'backend-service' chart is a "convenience" chart from Unique AG that can generically be used to deploy backend workloads to Kubernetes.
 

--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -16,4 +16,4 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: changed
-      description: "Support for injecting global volumeMounts into ExtraCronJobs templates"
+      description: "add audit volume mount support for extracronjobs templates"

--- a/charts/backend-service/README.md
+++ b/charts/backend-service/README.md
@@ -4,7 +4,7 @@ The 'backend-service' chart is a "convenience" chart from Unique AG that can gen
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 4.4.0](https://img.shields.io/badge/Version-4.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.5.0](https://img.shields.io/badge/Version-4.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -12,10 +12,10 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 This chart is available both as Helm Repository as well as OCI artefact.
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-backend-service unique/backend-service --version 4.4.0
+helm install my-backend-service unique/backend-service --version 4.5.0
 
 # or
-helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 4.4.0
+helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 4.5.0
 ```
 
 ### Docker Images

--- a/charts/backend-service/templates/extra-cronjobs.yaml
+++ b/charts/backend-service/templates/extra-cronjobs.yaml
@@ -64,7 +64,6 @@ spec:
                 - name: audit
                   mountPath: {{ default "/audit" .Values.auditVolume.mountPath }}
               {{- end }}
-
               {{- if $globalValues.secretProvider }}
               {{- range $k, $v := $globalValues.secretProvider.vaults }}
                 - name: {{ $fullName }}-{{ $k }}

--- a/charts/backend-service/templates/extra-cronjobs.yaml
+++ b/charts/backend-service/templates/extra-cronjobs.yaml
@@ -57,12 +57,12 @@ spec:
               resources:
                 {{- toYaml ($value.resources | default $globalValues.resources) | nindent 16 }}
               volumeMounts:
-              {{- with $globalValues.volumeMounts }}
-                {{- toYaml . | nindent 16 }}
-              {{- end }}
               {{- if $globalValues.auditVolume.enabled }}
                 - name: audit
                   mountPath: {{ default "/audit" .$globalValues.auditVolume.mountPath }}
+              {{- end }}
+              {{- with $globalValues.volumeMounts }}
+                {{- toYaml . | nindent 16 }}
               {{- end }}
               {{- if $globalValues.secretProvider }}
               {{- range $k, $v := $globalValues.secretProvider.vaults }}

--- a/charts/backend-service/templates/extra-cronjobs.yaml
+++ b/charts/backend-service/templates/extra-cronjobs.yaml
@@ -62,7 +62,7 @@ spec:
               {{- end }}
               {{- if $globalValues.auditVolume.enabled }}
                 - name: audit
-                  mountPath: {{ default "/audit" .Values.auditVolume.mountPath }}
+                  mountPath: {{ default "/audit" .$globalValues.auditVolume.mountPath }}
               {{- end }}
               {{- if $globalValues.secretProvider }}
               {{- range $k, $v := $globalValues.secretProvider.vaults }}

--- a/charts/backend-service/templates/extra-cronjobs.yaml
+++ b/charts/backend-service/templates/extra-cronjobs.yaml
@@ -57,12 +57,12 @@ spec:
               resources:
                 {{- toYaml ($value.resources | default $globalValues.resources) | nindent 16 }}
               volumeMounts:
-              {{- if $globalValues.auditVolume.enabled }}
-                - name: audit
-                  mountPath: {{ default "/audit" .$globalValues.auditVolume.mountPath }}
-              {{- end }}
               {{- with $globalValues.volumeMounts }}
                 {{- toYaml . | nindent 16 }}
+              {{- end }}
+              {{- if $globalValues.auditVolume.enabled }}
+                - name: audit
+                  mountPath: {{ default "/audit" $globalValues.auditVolume.mountPath }}
               {{- end }}
               {{- if $globalValues.secretProvider }}
               {{- range $k, $v := $globalValues.secretProvider.vaults }}

--- a/charts/backend-service/templates/extra-cronjobs.yaml
+++ b/charts/backend-service/templates/extra-cronjobs.yaml
@@ -60,6 +60,11 @@ spec:
               {{- with $globalValues.volumeMounts }}
                 {{- toYaml . | nindent 16 }}
               {{- end }}
+              {{- if $globalValues.auditVolume.enabled }}
+                - name: audit
+                  mountPath: {{ default "/audit" .Values.auditVolume.mountPath }}
+              {{- end }}
+
               {{- if $globalValues.secretProvider }}
               {{- range $k, $v := $globalValues.secretProvider.vaults }}
                 - name: {{ $fullName }}-{{ $k }}


### PR DESCRIPTION
This pull request updates the `backend-service` Helm chart to version 4.5.0, introduces new functionality for audit volume configuration, and updates the documentation accordingly.

### Version Update:
* [`charts/backend-service/Chart.yaml`](diffhunk://#diff-6d4eea04b3a722161a691220447eb14e4d5d0e6a5098a90560a1cb1114beed8fL10-R10): Updated the chart version from `4.4.0` to `4.5.0`.
* [`charts/backend-service/README.md`](diffhunk://#diff-665570d6bdacaf97b119492af1bbbbdc25c5b4a952bd9d8f1341554d0dbf7661L7-R18): Updated all references to the chart version from `4.4.0` to `4.5.0` in the documentation and installation examples.

### New Feature - Audit Volume:
* [`charts/backend-service/templates/extra-cronjobs.yaml`](diffhunk://#diff-17dddb96e3a53edaa5f41591c8f4da488cf23e3585269cd4fc380bb3bd399889R63-R66): Added support for an optional `auditVolume` configuration, allowing users to specify an audit volume mount path.