### PR TITLE
feat(backend-service): render service monitor if service is disabled

### DIFF
--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -8,7 +8,7 @@ name: backend-service
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/backend-service
 # change on next major: enable netpol by default, deprecate cronJob
-version: 5.5.0
+version: 5.6.0
 appVersion: latest
 description: |
   The 'backend-service' chart is a "convenience" chart from Unique AG that can generically be used to deploy backend workloads to Kubernetes.
@@ -18,4 +18,6 @@ annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
     - kind: added
-      description: "possibility to add annotations to the service"
+      description: "PodMonitor is added when service is disabled"
+    - kind: changed
+      description: "ServiceMonitor is rendered only when service is enabled"

--- a/charts/backend-service/README.md
+++ b/charts/backend-service/README.md
@@ -4,7 +4,7 @@ The 'backend-service' chart is a "convenience" chart from Unique AG that can gen
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 5.5.0](https://img.shields.io/badge/Version-5.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 5.6.0](https://img.shields.io/badge/Version-5.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -12,10 +12,10 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 This chart is available both as Helm Repository as well as OCI artefact.
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-backend-service unique/backend-service --version 5.5.0
+helm install my-backend-service unique/backend-service --version 5.6.0
 
 # or
-helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 5.5.0
+helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 5.6.0
 ```
 
 ### Docker Images

--- a/charts/backend-service/templates/podmonitor.yaml
+++ b/charts/backend-service/templates/podmonitor.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.service.enabled .Values.prometheus.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- if and (not .Values.service.enabled) .Values.prometheus.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: {{ include "backendService.fullname" . }}
   labels:
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "backendService.serviceLabels" . | nindent 6 }}
-  endpoints:
+      {{- include "backendService.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
   - port: {{ hasKey .Values.ports "metrics" | ternary "metrics" "http" }}
 {{- end }}

--- a/charts/backend-service/tests/podmonitor._test.yaml
+++ b/charts/backend-service/tests/podmonitor._test.yaml
@@ -1,0 +1,98 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Regression Test PodMonitor
+templates:
+  - podmonitor.yaml
+  - deployment.yaml
+  - deployment-env.yaml
+release:
+  name: ut
+tests:
+  - it: When given port for metrics
+    set:
+      image.tag: pinned-version
+      ports.metrics: 9003
+      service.enabled: false
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: podmonitor.yaml
+    asserts:
+      - equal:
+          path: spec.podMetricsEndpoints[0].port
+          value: metrics
+
+  - it: When not given port for metrics
+    set:
+      image.tag: pinned-version
+      service.enabled: false
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: podmonitor.yaml
+    asserts:
+      - equal:
+          path: spec.podMetricsEndpoints[0].port
+          value: http
+
+  - it: PodMonitor matchLabels should match Deployment selector labels
+    set:
+      image.tag: pinned-version
+      service.enabled: false
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: ut
+            app.kubernetes.io/instance: ut
+            app.kubernetes.io/component: server
+      - template: podmonitor.yaml
+        hasDocuments:
+          count: 1
+      - template: podmonitor.yaml
+        equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: ut
+            app.kubernetes.io/instance: ut
+            app.kubernetes.io/component: server
+
+  - it: PodMonitor should not be created when service is enabled
+    set:
+      image.tag: pinned-version
+      service.enabled: true
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: podmonitor.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: PodMonitor should not be created when prometheus is disabled
+    set:
+      image.tag: pinned-version
+      service.enabled: false
+      prometheus.enabled: false
+    capabilities:
+      apiVersions:
+        - monitoring.coreos.com/v1
+    template: podmonitor.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: PodMonitor should not be created when monitoring API is not available
+    set:
+      image.tag: pinned-version
+      service.enabled: false
+    template: podmonitor.yaml
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Describe your changes

- PodMonitor is added when service is disabled
- ServiceMonitor is rendered only when service is enabled

## Checklist before requesting a review
- [x] Chart version bumped (`Chart.yaml`) <!-- Respect proper [semver](https://semver.org)  -->
- [x] Values schema updated (`values.schema.json`) <!-- Chart installation/templating will fail if not changed at deploy time, add a Unit or CI Test to ensure your changes work end to end -->
- [x] Changes updated in [ArtifactHub syntax](https://artifacthub.io/docs/topics/annotations/helm) (`Chart.yaml`) <!-- Changes are incremental, delete all previous changes and don't repeat the change type in the message -->
- [x] Pre-Commit passed or has been run manually (`Makefile`)
