### PR TITLE
chore(agent-sandbox-controller): bump to upstream v0.4.5

### DIFF
--- a/charts/agent-sandbox-controller/Chart.yaml
+++ b/charts/agent-sandbox-controller/Chart.yaml
@@ -8,8 +8,8 @@ name: agent-sandbox-controller
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/agent-sandbox-controller
   - https://github.com/kubernetes-sigs/agent-sandbox
-version: 0.4.2-rc.1
-appVersion: "v0.4.2"
+version: 0.4.5-rc.1
+appVersion: "v0.4.5"
 description: |
   Helm chart for the Agent Sandbox controller — a Kubernetes CRD and controller for managing isolated, stateful, singleton workloads (e.g. AI agent runtimes).
 
@@ -17,5 +17,7 @@ description: |
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
-    - kind: added
-      description: Initial release of the agent-sandbox-controller chart packaging the upstream kubernetes-sigs/agent-sandbox controller and router.
+    - kind: changed
+      description: Bumped upstream agent-sandbox to v0.4.5 (controller image, router image, and CRDs).
+    - kind: security
+      description: Removed `pods` `create`/`delete` verbs from the extensions ClusterRole to align with upstream RBAC hardening.

--- a/charts/agent-sandbox-controller/README.md
+++ b/charts/agent-sandbox-controller/README.md
@@ -4,14 +4,14 @@ Helm chart for the Agent Sandbox controller — a Kubernetes CRD and controller 
 
 Upstream project: https://github.com/kubernetes-sigs/agent-sandbox
 
-![Version: 0.4.2-rc.1](https://img.shields.io/badge/Version-0.4.2--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.2](https://img.shields.io/badge/AppVersion-v0.4.2-informational?style=flat-square)
+![Version: 0.4.5-rc.1](https://img.shields.io/badge/Version-0.4.5--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.5](https://img.shields.io/badge/AppVersion-v0.4.5-informational?style=flat-square)
 
 ## Installation
 
 Releases are published as OCI artifacts to GHCR.
 
 ```sh
-helm install my-agent-sandbox-controller oci://ghcr.io/unique-ag/helm-charts/agent-sandbox-controller --version 0.4.2-rc.1
+helm install my-agent-sandbox-controller oci://ghcr.io/unique-ag/helm-charts/agent-sandbox-controller --version 0.4.5-rc.1
 ```
 
 ## Implementation Details
@@ -44,8 +44,8 @@ The Python SDK tunnel mode auto-discovers a service named `sandbox-router-svc`. 
 | extensions | object | `{"enabled":true}` | Enable the upstream sandbox extensions controller (`SandboxClaim`, `SandboxTemplate`, `SandboxWarmPool`). |
 | extensions.enabled | bool | `true` | Toggle the extensions controller and its RBAC. |
 | fullnameOverride | string | `""` | This is to override the full name. |
-| image | object | `{"digest":"sha256:5c06f4dc301cf598a6b548b1e14dba3cb9519dd6f74c9d316dac9bac3f3dfae3","pullPolicy":"IfNotPresent","repository":"registry.k8s.io/agent-sandbox/agent-sandbox-controller","tag":""}` | Container image used by the controller. |
-| image.digest | string | `"sha256:5c06f4dc301cf598a6b548b1e14dba3cb9519dd6f74c9d316dac9bac3f3dfae3"` | Pin a specific image by digest. Recommended for supply-chain integrity. |
+| image | object | `{"digest":"sha256:64317cf5694991d9d63ce6a1b3fda16dfeecca0f01c863945cbcdb38ccc18473","pullPolicy":"IfNotPresent","repository":"registry.k8s.io/agent-sandbox/agent-sandbox-controller","tag":""}` | Container image used by the controller. |
+| image.digest | string | `"sha256:64317cf5694991d9d63ce6a1b3fda16dfeecca0f01c863945cbcdb38ccc18473"` | Pin a specific image by digest. Recommended for supply-chain integrity. |
 | image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | image.repository | string | `"registry.k8s.io/agent-sandbox/agent-sandbox-controller"` | This sets the image repository. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
@@ -55,15 +55,15 @@ The Python SDK tunnel mode auto-discovers a service named `sandbox-router-svc`. 
 | podSecurityContext | object | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level security context applied to the controller pod. |
 | replicaCount | int | `1` | Number of controller replicas. Leader election is used to elect a single active leader. |
 | resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Controller container resource requests and limits. |
-| router | object | `{"containerPort":8080,"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000},"enabled":true,"image":{"digest":"sha256:c3a59a867e66dc70c6e2eb56f40b840f5b3ca2b8ba44be318c6bf163226fd8df","pullPolicy":"IfNotPresent","repository":"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router","tag":"v20260422-v0.4.2"},"livenessProbe":{"initialDelaySeconds":10,"path":"/healthz","periodSeconds":10},"networkPolicy":{"egress":{"sandboxNamespaceSelector":{},"sandboxPort":8888},"enabled":true,"ingress":{"allowedCIDRs":[],"allowedSources":[]}},"podSecurityContext":{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}},"proxyTimeoutSeconds":180,"readinessProbe":{"initialDelaySeconds":5,"path":"/healthz","periodSeconds":5},"replicaCount":2,"resources":{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"service":{"name":"","port":8080,"type":"ClusterIP"},"topologySpreadConstraints":{"enabled":true,"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}}` | Sandbox router subchart configuration. The router proxies traffic to sandbox pods and is required for the Python SDK tunnel mode. |
+| router | object | `{"containerPort":8080,"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000},"enabled":true,"image":{"digest":"sha256:2a3a21a5055051109c7ac8230d3d1c83d7f5f50279ae2c669433bb4d16a93e19","pullPolicy":"IfNotPresent","repository":"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router","tag":"v20260506-v0.4.5"},"livenessProbe":{"initialDelaySeconds":10,"path":"/healthz","periodSeconds":10},"networkPolicy":{"egress":{"sandboxNamespaceSelector":{},"sandboxPort":8888},"enabled":true,"ingress":{"allowedCIDRs":[],"allowedSources":[]}},"podSecurityContext":{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}},"proxyTimeoutSeconds":180,"readinessProbe":{"initialDelaySeconds":5,"path":"/healthz","periodSeconds":5},"replicaCount":2,"resources":{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"service":{"name":"","port":8080,"type":"ClusterIP"},"topologySpreadConstraints":{"enabled":true,"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}}` | Sandbox router subchart configuration. The router proxies traffic to sandbox pods and is required for the Python SDK tunnel mode. |
 | router.containerPort | int | `8080` | Container port the router listens on inside the pod. |
 | router.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Container-level security context applied to the router container. |
 | router.enabled | bool | `true` | Toggle the sandbox router deployment, service, and network policy. |
-| router.image | object | `{"digest":"sha256:c3a59a867e66dc70c6e2eb56f40b840f5b3ca2b8ba44be318c6bf163226fd8df","pullPolicy":"IfNotPresent","repository":"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router","tag":"v20260422-v0.4.2"}` | Container image used by the router. |
-| router.image.digest | string | `"sha256:c3a59a867e66dc70c6e2eb56f40b840f5b3ca2b8ba44be318c6bf163226fd8df"` | Pin a specific router image by digest. |
+| router.image | object | `{"digest":"sha256:2a3a21a5055051109c7ac8230d3d1c83d7f5f50279ae2c669433bb4d16a93e19","pullPolicy":"IfNotPresent","repository":"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router","tag":"v20260506-v0.4.5"}` | Container image used by the router. |
+| router.image.digest | string | `"sha256:2a3a21a5055051109c7ac8230d3d1c83d7f5f50279ae2c669433bb4d16a93e19"` | Pin a specific router image by digest. |
 | router.image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for the router image. |
 | router.image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router"` | This sets the router image repository. |
-| router.image.tag | string | `"v20260422-v0.4.2"` | Overrides the router image tag. |
+| router.image.tag | string | `"v20260506-v0.4.5"` | Overrides the router image tag. |
 | router.livenessProbe | object | `{"initialDelaySeconds":10,"path":"/healthz","periodSeconds":10}` | HTTP liveness probe configuration for the router. |
 | router.networkPolicy | object | `{"egress":{"sandboxNamespaceSelector":{},"sandboxPort":8888},"enabled":true,"ingress":{"allowedCIDRs":[],"allowedSources":[]}}` | `NetworkPolicy` for the router pod. |
 | router.networkPolicy.egress | object | `{"sandboxNamespaceSelector":{},"sandboxPort":8888}` | Egress rules. By default the router needs to reach DNS and sandbox pods. |

--- a/charts/agent-sandbox-controller/crds/crds.yaml
+++ b/charts/agent-sandbox-controller/crds/crds.yaml
@@ -513,7 +513,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -569,7 +569,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -591,7 +591,7 @@ spec:
                                   configMapRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -602,7 +602,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -759,7 +759,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -866,7 +866,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1090,7 +1090,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1265,7 +1265,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -1321,7 +1321,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -1343,7 +1343,7 @@ spec:
                                   configMapRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -1354,7 +1354,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -1511,7 +1511,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1618,7 +1618,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1842,7 +1842,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -1998,7 +1998,7 @@ spec:
                         items:
                           properties:
                             name:
-                              default: ''
+                              default: ""
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -2033,7 +2033,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2089,7 +2089,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -2111,7 +2111,7 @@ spec:
                                   configMapRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2122,7 +2122,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -2279,7 +2279,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2386,7 +2386,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -2610,7 +2610,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -3069,7 +3069,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3087,7 +3087,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3118,7 +3118,7 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 name:
-                                  default: ''
+                                  default: ""
                                   type: string
                                 optional:
                                   type: boolean
@@ -3133,7 +3133,7 @@ spec:
                                 nodePublishSecretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3335,7 +3335,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3430,7 +3430,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3550,7 +3550,7 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -3640,7 +3640,7 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -3702,7 +3702,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3727,7 +3727,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3782,7 +3782,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -3952,6 +3952,7 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-type: atomic
             required:
             - podTemplate
             type: object
@@ -4020,7 +4021,6 @@ spec:
         statusReplicasPath: .status.replicas
       status: {}
 ---
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -4088,6 +4088,10 @@ spec:
                   shutdownTime:
                     format: date-time
                     type: string
+                  ttlSecondsAfterFinished:
+                    format: int32
+                    minimum: 0
+                    type: integer
                 type: object
               sandboxTemplateRef:
                 properties:
@@ -4157,7 +4161,6 @@ spec:
     storage: true
     subresources:
       status: {}
----
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4872,7 +4875,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -4928,7 +4931,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -4950,7 +4953,7 @@ spec:
                                   configMapRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -4961,7 +4964,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -5118,7 +5121,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -5225,7 +5228,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -5449,7 +5452,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -5624,7 +5627,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -5680,7 +5683,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -5702,7 +5705,7 @@ spec:
                                   configMapRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -5713,7 +5716,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -5870,7 +5873,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -5977,7 +5980,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -6201,7 +6204,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -6357,7 +6360,7 @@ spec:
                         items:
                           properties:
                             name:
-                              default: ''
+                              default: ""
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -6392,7 +6395,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -6448,7 +6451,7 @@ spec:
                                           key:
                                             type: string
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -6470,7 +6473,7 @@ spec:
                                   configMapRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -6481,7 +6484,7 @@ spec:
                                   secretRef:
                                     properties:
                                       name:
-                                        default: ''
+                                        default: ""
                                         type: string
                                       optional:
                                         type: boolean
@@ -6638,7 +6641,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -6745,7 +6748,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -6969,7 +6972,7 @@ spec:
                                       format: int32
                                       type: integer
                                     service:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   required:
                                   - port
@@ -7428,7 +7431,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -7446,7 +7449,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -7477,7 +7480,7 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 name:
-                                  default: ''
+                                  default: ""
                                   type: string
                                 optional:
                                   type: boolean
@@ -7492,7 +7495,7 @@ spec:
                                 nodePublishSecretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -7694,7 +7697,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -7789,7 +7792,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -7909,7 +7912,7 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -7999,7 +8002,7 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                           name:
-                                            default: ''
+                                            default: ""
                                             type: string
                                           optional:
                                             type: boolean
@@ -8061,7 +8064,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -8086,7 +8089,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -8141,7 +8144,7 @@ spec:
                                 secretRef:
                                   properties:
                                     name:
-                                      default: ''
+                                      default: ""
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
@@ -8188,6 +8191,115 @@ spec:
                 required:
                 - spec
                 type: object
+              volumeClaimTemplates:
+                items:
+                  properties:
+                    metadata:
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                      type: object
+                    spec:
+                      properties:
+                        accessModes:
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        dataSource:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        dataSourceRef:
+                          properties:
+                            apiGroup:
+                              type: string
+                            kind:
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        selector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  operator:
+                                    type: string
+                                  values:
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        storageClassName:
+                          type: string
+                        volumeAttributesClassName:
+                          type: string
+                        volumeMode:
+                          type: string
+                        volumeName:
+                          type: string
+                      type: object
+                  required:
+                  - spec
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
             required:
             - podTemplate
             type: object
@@ -8200,7 +8312,6 @@ spec:
     storage: true
     subresources:
       status: {}
----
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/agent-sandbox-controller/templates/clusterrole.yaml
+++ b/charts/agent-sandbox-controller/templates/clusterrole.yaml
@@ -72,8 +72,6 @@ rules:
   resources:
   - pods
   verbs:
-  - create
-  - delete
   - get
   - list
   - patch

--- a/charts/agent-sandbox-controller/values.yaml
+++ b/charts/agent-sandbox-controller/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
   # -- Pin a specific image by digest. Recommended for supply-chain integrity.
-  digest: sha256:5c06f4dc301cf598a6b548b1e14dba3cb9519dd6f74c9d316dac9bac3f3dfae3
+  digest: sha256:64317cf5694991d9d63ce6a1b3fda16dfeecca0f01c863945cbcdb38ccc18473
   # -- This sets the pull policy for images.
   pullPolicy: IfNotPresent
 
@@ -85,9 +85,9 @@ router:
     # -- This sets the router image repository.
     repository: us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router
     # -- Overrides the router image tag.
-    tag: v20260422-v0.4.2
+    tag: v20260506-v0.4.5
     # -- Pin a specific router image by digest.
-    digest: sha256:c3a59a867e66dc70c6e2eb56f40b840f5b3ca2b8ba44be318c6bf163226fd8df
+    digest: sha256:2a3a21a5055051109c7ac8230d3d1c83d7f5f50279ae2c669433bb4d16a93e19
     # -- This sets the pull policy for the router image.
     pullPolicy: IfNotPresent
   # -- Router `Service` settings.


### PR DESCRIPTION
## Summary

Bumps the `agent-sandbox-controller` chart to track upstream [`kubernetes-sigs/agent-sandbox` v0.4.5](https://github.com/kubernetes-sigs/agent-sandbox/releases/tag/v0.4.5).

| Item | From | To |
|------|------|-----|
| `appVersion` | `v0.4.2` | `v0.4.5` |
| Chart `version` | `0.4.2-rc.1` | `0.4.5-rc.1` |
| Controller image digest | `sha256:5c06f4dc…3f3dfae3` | `sha256:64317cf5…ccc18473` |
| Router image tag | `v20260422-v0.4.2` | `v20260506-v0.4.5` |
| Router image digest | `sha256:c3a59a86…226fd8df` | `sha256:2a3a21a5…16a93e19` |

### Changes

- Sync CRDs (`crds/crds.yaml`) from the upstream v0.4.5 `manifest.yaml` + `extensions.yaml` release artifacts. Notable schema additions: `ttlSecondsAfterFinished` field and `x-kubernetes-list-type: atomic` markers.
- Drop `pods` `create` / `delete` verbs from the extensions `ClusterRole` to match the upstream RBAC hardening called out in the v0.4.5 release notes (Kyverno examples preventing privilege escalation).
- Regenerate `README.md` via `helm-docs` (1.14.2).

### Heads-up about upstream breaking change

v0.4.5 promotes `PodSnapshot` from `v1alpha1` to `v1` and requires the `agents.x-k8s.io/sandbox-name-hash` label on `PodSnapshotPolicy` grouping rules. This affects users of the GKE `PodSnapshot` extension and the Python SDK only — the controller chart itself does not manage `PodSnapshot` / `PodSnapshotPolicy` resources, so no chart-level migration is needed.

## Test plan

- [x] `helm lint charts/agent-sandbox-controller` passes
- [x] `helm unittest charts/agent-sandbox-controller` — 9/9 tests pass
- [x] `helm template …` renders the controller image as `registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.4.5@sha256:64317cf5…` and the router image as `…sandbox-router:v20260506-v0.4.5@sha256:2a3a21a5…`
- [x] `helm-docs` regenerated cleanly
- [ ] CI: `chart-testing` lint + install
- [ ] Smoke test in a dev cluster