### PR TITLE
fix(kong-plugins): prevent x-user-roles spoofing in unique-jwt-auth

### DIFF
--- a/charts/kong-plugins/Chart.yaml
+++ b/charts/kong-plugins/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: unique-ag
     url: https://unique.ch/
 name: kong-plugins
-version: 2.3.0
+version: 2.3.1
 description: |
   The 'kong-plugins' chart provides a streamlined solution for deploying Kong plugins via ConfigMaps to be used with the Unique Software.
 
@@ -14,5 +14,5 @@ description: |
   Please report any security concerns with the plugins via the [Security Policy](https://github.com/Unique-AG/helm-charts/tree/main?tab=security-ov-file).
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Future releases are OCI-only. The Helm repository is frozen and will not receive new versions."
+    - kind: fixed
+      description: Prevent client-supplied x-user-roles header from being forwarded upstream in unique-jwt-auth

--- a/charts/kong-plugins/README.md
+++ b/charts/kong-plugins/README.md
@@ -6,7 +6,7 @@ Refer to each plugins readme section to learn more about them.
 
 Please report any security concerns with the plugins via the [Security Policy](https://github.com/Unique-AG/helm-charts/tree/main?tab=security-ov-file).
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -15,7 +15,7 @@ Please report any security concerns with the plugins via the [Security Policy](h
 New releases are published as OCI artifacts only. The Helm repository index is frozen and will not receive new versions—see the [repository README](https://github.com/Unique-AG/helm-charts/blob/main/README.md#migrating-to-oci) for migration steps.
 
 ```sh
-helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --version 2.3.0
+helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --version 2.3.1
 ```
 
 <details>
@@ -23,7 +23,7 @@ helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --
 
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-kong-plugins unique/kong-plugins --version 2.3.0
+helm install my-kong-plugins unique/kong-plugins --version 2.3.1
 ```
 
 </details>

--- a/charts/kong-plugins/files/unique-jwt-auth/handler.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/handler.lua
@@ -156,6 +156,7 @@ end
 -------------------------------------------------------------------------------
 local function custom_set_unique_headers(conf, jwt_claims)
     local set_header = kong.service.request.set_header
+    local clear_header = kong.service.request.clear_header
     -- Set x-user-id
     set_header("x-user-id", jwt_claims.sub)
 
@@ -166,6 +167,7 @@ local function custom_set_unique_headers(conf, jwt_claims)
 
     -- Set x-user-roles if conf.zitadel_project_id is specified
     if conf.zitadel_project_id then
+        clear_header("x-user-roles")
         local project_roles_key = "urn:zitadel:iam:org:project:" .. conf.zitadel_project_id .. ":roles"
         local project_roles = jwt_claims[project_roles_key]
 

--- a/charts/kong-plugins/files/unique-jwt-auth/handler.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/handler.lua
@@ -159,6 +159,7 @@ local function custom_set_unique_headers(conf, jwt_claims)
     local clear_header = kong.service.request.clear_header
     -- Set x-user-id
     set_header("x-user-id", jwt_claims.sub)
+    clear_header("x-user-roles")
 
     -- Set x-company-id, x-company-name, and x-company-domain
     set_header("x-company-id", jwt_claims["urn:zitadel:iam:user:resourceowner:id"])
@@ -167,7 +168,6 @@ local function custom_set_unique_headers(conf, jwt_claims)
 
     -- Set x-user-roles if conf.zitadel_project_id is specified
     if conf.zitadel_project_id then
-        clear_header("x-user-roles")
         local project_roles_key = "urn:zitadel:iam:org:project:" .. conf.zitadel_project_id .. ":roles"
         local project_roles = jwt_claims[project_roles_key]
 


### PR DESCRIPTION
## Summary

- When a user has no roles on the configured Zitadel project, the `urn:zitadel:iam:org:project:<id>:roles` claim is omitted from the JWT entirely.
- In that case `unique-jwt-auth` skipped setting the upstream `x-user-roles` header, so any client-supplied `x-user-roles` from the original request was forwarded to the backend, allowing role injection.
- Clear `x-user-roles` before attempting to populate it from JWT claims (when `zitadel_project_id` is configured), matching the existing behavior in `unique-app-repo-auth`.
- Bumps `kong-plugins` chart to `2.3.1`.

## Caveat

The header is still only cleared when `zitadel_project_id` is set. Routes using `unique-jwt-auth` without that option remain susceptible to the same spoofing — happy to extend the fix to clear unconditionally if preferred.

## Test plan

- [ ] Deploy chart `2.3.1` against a route with `zitadel_project_id` configured.
- [ ] Token without project roles + request carrying `x-user-roles: admin` → upstream sees no `x-user-roles` header.
- [ ] Token with project roles → upstream sees `x-user-roles` populated from JWT only.
- [ ] Token without project roles and no incoming header → upstream sees no `x-user-roles` header (unchanged).