### PR TITLE
fix(backend-service): add support for sync-wave

### DIFF
--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -19,7 +19,3 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: "Render ArgoCD sync-wave -5 on hook ServiceAccounts so they are applied before hook Jobs."
-    - kind: fixed
-      description: "When digest is passed to the image tag, the Deployments version labels strips it again to respect the length limit of kubernetes labels."
-    - kind: added
-      description: "Explicit and native support for digest pinning."

--- a/charts/backend-service/Chart.yaml
+++ b/charts/backend-service/Chart.yaml
@@ -8,7 +8,7 @@ name: backend-service
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/backend-service
 # changes to consider on next major: enable netpol by default
-version: 10.5.0
+version: 10.5.1
 appVersion: latest
 description: |
   The 'backend-service' chart is a "convenience" chart from Unique AG that can generically be used to deploy backend workloads to Kubernetes.
@@ -17,6 +17,8 @@ description: |
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "Render ArgoCD sync-wave -5 on hook ServiceAccounts so they are applied before hook Jobs."
     - kind: fixed
       description: "When digest is passed to the image tag, the Deployments version labels strips it again to respect the length limit of kubernetes labels."
     - kind: added

--- a/charts/backend-service/README.md
+++ b/charts/backend-service/README.md
@@ -4,7 +4,7 @@ The 'backend-service' chart is a "convenience" chart from Unique AG that can gen
 
 Note that this chart assumes that you have a valid contract with Unique AG and thus access to the required Docker images.
 
-![Version: 10.5.0](https://img.shields.io/badge/Version-10.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 10.5.1](https://img.shields.io/badge/Version-10.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -13,7 +13,7 @@ Note that this chart assumes that you have a valid contract with Unique AG and t
 New releases are published as OCI artifacts only. The Helm repository index is frozen and will not receive new versions—see the [repository README](https://github.com/Unique-AG/helm-charts/blob/main/README.md#migrating-to-oci) for migration steps.
 
 ```sh
-helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 10.5.0
+helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-service --version 10.5.1
 ```
 
 <details>
@@ -21,7 +21,7 @@ helm install my-backend-service oci://ghcr.io/unique-ag/helm-charts/backend-serv
 
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-backend-service unique/backend-service --version 10.5.0
+helm install my-backend-service unique/backend-service --version 10.5.1
 ```
 
 </details>

--- a/charts/backend-service/templates/hooks/serviceaccount.yaml
+++ b/charts/backend-service/templates/hooks/serviceaccount.yaml
@@ -6,6 +6,7 @@
 {{- end }}
 {{- end }}
 {{- if $hasEnabledHook }}
+{{- $serviceAccountAnnotations := .Values.serviceAccount.annotations | default dict }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,10 +14,12 @@ metadata:
   labels:
     {{- include "backendService.mutableLabels" . | nindent 4 }}
   annotations:
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with $serviceAccountAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-    # we need to install the service account before the hooks, otherwise it can not be used
+  {{- if not (hasKey $serviceAccountAnnotations "argocd.argoproj.io/sync-wave") }}
+    argocd.argoproj.io/sync-wave: "-5"
+  {{- end }}
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "1"
     helm.sh/hook-delete-policy: before-hook-creation

--- a/charts/backend-service/tests/hooks-multiple._test.yaml
+++ b/charts/backend-service/tests/hooks-multiple._test.yaml
@@ -151,6 +151,27 @@ tests:
       - equal:
           path: metadata.name
           value: ut-hooks
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-5"
+
+  - it: When serviceAccount sync-wave annotation is set, should preserve the override
+    set:
+      image.tag: pinned-version
+      serviceAccount.enabled: true
+      serviceAccount.annotations:
+        argocd.argoproj.io/sync-wave: "-10"
+      hooks.migration.enabled: true
+      hooks.migration.command: npm run migrate
+    template: hooks/serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-10"
 
   - it: When multiple hooks are enabled, both Jobs should reference the shared ServiceAccount
     set:


### PR DESCRIPTION
## Describe your changes

Refs: Refs: https://unique-ch.atlassian.net/browse/UN-20915
Fixes the services that read legacy charts

## Checklist before requesting a review
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/helm-charts/blob/main/CONTRIBUTING.md) read and understood
- [x] Chart version bumped (`Chart.yaml`) <!-- Respect proper [semver](https://semver.org)  -->
- [ ] Values schema updated (`values.schema.json`) <!-- Chart installation/templating will fail if not changed at deploy time, add a Unit or CI Test to ensure your changes work end to end -->
- [x] Changes updated in [ArtifactHub syntax](https://artifacthub.io/docs/topics/annotations/helm) (`Chart.yaml`) <!-- Changes are incremental, delete all previous changes and don't repeat the change type in the message -->
- [x] Pre-Commit passed or has been run manually (`Makefile`)

Reuses existing `serviceAccount.annotations` so doesnt need `values.schema.json` update.