### PR TITLE
fix(kong-plugins): detect forwarded for ip

### DIFF
--- a/charts/kong-plugins/Chart.yaml
+++ b/charts/kong-plugins/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: unique-ag
     url: https://unique.ch/
 name: kong-plugins
-version: 2.3.0
+version: 2.3.1
 description: |
   The 'kong-plugins' chart provides a streamlined solution for deploying Kong plugins via ConfigMaps to be used with the Unique Software.
 
@@ -14,5 +14,5 @@ description: |
   Please report any security concerns with the plugins via the [Security Policy](https://github.com/Unique-AG/helm-charts/tree/main?tab=security-ov-file).
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Future releases are OCI-only. The Helm repository is frozen and will not receive new versions."
+    - kind: fixed
+      description: "Log the correct client IP instead of the Azure Application Gateway's internal IP in JWT auth warnings."

--- a/charts/kong-plugins/Chart.yaml
+++ b/charts/kong-plugins/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: unique-ag
     url: https://unique.ch/
 name: kong-plugins
-version: 2.3.1
+version: 2.3.2
 description: |
   The 'kong-plugins' chart provides a streamlined solution for deploying Kong plugins via ConfigMaps to be used with the Unique Software.
 

--- a/charts/kong-plugins/README.md
+++ b/charts/kong-plugins/README.md
@@ -6,7 +6,7 @@ Refer to each plugins readme section to learn more about them.
 
 Please report any security concerns with the plugins via the [Security Policy](https://github.com/Unique-AG/helm-charts/tree/main?tab=security-ov-file).
 
-![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -15,7 +15,7 @@ Please report any security concerns with the plugins via the [Security Policy](h
 New releases are published as OCI artifacts only. The Helm repository index is frozen and will not receive new versions—see the [repository README](https://github.com/Unique-AG/helm-charts/blob/main/README.md#migrating-to-oci) for migration steps.
 
 ```sh
-helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --version 2.3.0
+helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --version 2.3.1
 ```
 
 <details>
@@ -23,7 +23,7 @@ helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --
 
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-kong-plugins unique/kong-plugins --version 2.3.0
+helm install my-kong-plugins unique/kong-plugins --version 2.3.1
 ```
 
 </details>
@@ -83,16 +83,16 @@ Default metric name: `unique_jwt_auth_security_warnings_total`
 
 Possible `reason` label values:
 
-| reason | description |
-|--------|-------------|
-| `invalid_signature` | Token signature could not be verified against any known key |
-| `multiple_tokens` | More than one token was found in the request |
-| `unrecognizable_token_type` | Token is neither a string nor a table |
-| `malformed_jwt` | Token could not be decoded as a JWT |
-| `disallowed_issuer` | Token `iss` claim does not match `allowed_iss` |
-| `unexpected_algorithm` | Token `alg` header does not match configured `algorithm` |
-| `claims_validation_failed` | Registered claims (`exp`, `nbf`) failed verification |
-| `max_expiration_exceeded` | Token lifetime exceeds `maximum_expiration` |
+| reason | description | log query |
+|--------|-------------|-----------|
+| `invalid_signature` | Token signature could not be verified against any known key | `{app="gateway"} \|= "invalid signature"` |
+| `multiple_tokens` | More than one token was found in the request | `{app="gateway"} \|= "Multiple tokens"` |
+| `unrecognizable_token_type` | Token is neither a string nor a table | `{app="gateway"} \|= "Unrecognizable token"` |
+| `malformed_jwt` | Token could not be decoded as a JWT | `{app="gateway"} \|= "Malformed JWT"` |
+| `disallowed_issuer` | Token `iss` claim does not match `allowed_iss` | `{app="gateway"} \|= "disallowed issuer"` |
+| `unexpected_algorithm` | Token `alg` header does not match configured `algorithm` | `{app="gateway"} \|= "unexpected algorithm"` |
+| `claims_validation_failed` | Registered claims (`exp`, `nbf`) failed verification | `{app="gateway"} \|= "claims validation failed"` |
+| `max_expiration_exceeded` | Token lifetime exceeds `maximum_expiration` | `{app="gateway"} \|= "maximum expiration"` |
 
 ### unique-app-repo-auth
 
@@ -100,12 +100,12 @@ Default metric name: `unique_app_repo_auth_security_warnings_total`
 
 Possible `reason` label values:
 
-| reason | description |
-|--------|-------------|
-| `api_key_validation_failed` | App repository returned a non-200 response for the API key |
-| `multiple_tokens` | More than one token was found in the request |
-| `unrecognizable_token_type` | Token is neither a string nor a table |
-| `missing_required_headers` | `x-app-id` or `x-company-id` header is absent |
+| reason | description | log query |
+|--------|-------------|-----------|
+| `api_key_validation_failed` | App repository returned a non-200 response for the API key | `{app="gateway"} \|= "API key validation"` |
+| `multiple_tokens` | More than one token was found in the request | `{app="gateway"} \|= "Multiple tokens"` |
+| `unrecognizable_token_type` | Token is neither a string nor a table | `{app="gateway"} \|= "Unrecognizable token"` |
+| `missing_required_headers` | `x-app-id` or `x-company-id` header is absent | `{app="gateway"} \|= "missing required headers"` |
 
 ### Example output
 

--- a/charts/kong-plugins/README.md
+++ b/charts/kong-plugins/README.md
@@ -6,7 +6,7 @@ Refer to each plugins readme section to learn more about them.
 
 Please report any security concerns with the plugins via the [Security Policy](https://github.com/Unique-AG/helm-charts/tree/main?tab=security-ov-file).
 
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.3.2](https://img.shields.io/badge/Version-2.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -15,7 +15,7 @@ Please report any security concerns with the plugins via the [Security Policy](h
 New releases are published as OCI artifacts only. The Helm repository index is frozen and will not receive new versions—see the [repository README](https://github.com/Unique-AG/helm-charts/blob/main/README.md#migrating-to-oci) for migration steps.
 
 ```sh
-helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --version 2.3.1
+helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --version 2.3.2
 ```
 
 <details>
@@ -23,7 +23,7 @@ helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --
 
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-kong-plugins unique/kong-plugins --version 2.3.1
+helm install my-kong-plugins unique/kong-plugins --version 2.3.2
 ```
 
 </details>

--- a/charts/kong-plugins/README.md.gotmpl
+++ b/charts/kong-plugins/README.md.gotmpl
@@ -80,16 +80,16 @@ Default metric name: `unique_jwt_auth_security_warnings_total`
 
 Possible `reason` label values:
 
-| reason | description |
-|--------|-------------|
-| `invalid_signature` | Token signature could not be verified against any known key |
-| `multiple_tokens` | More than one token was found in the request |
-| `unrecognizable_token_type` | Token is neither a string nor a table |
-| `malformed_jwt` | Token could not be decoded as a JWT |
-| `disallowed_issuer` | Token `iss` claim does not match `allowed_iss` |
-| `unexpected_algorithm` | Token `alg` header does not match configured `algorithm` |
-| `claims_validation_failed` | Registered claims (`exp`, `nbf`) failed verification |
-| `max_expiration_exceeded` | Token lifetime exceeds `maximum_expiration` |
+| reason | description | log query |
+|--------|-------------|-----------|
+| `invalid_signature` | Token signature could not be verified against any known key | `{app="gateway"} \|= "invalid signature"` |
+| `multiple_tokens` | More than one token was found in the request | `{app="gateway"} \|= "Multiple tokens"` |
+| `unrecognizable_token_type` | Token is neither a string nor a table | `{app="gateway"} \|= "Unrecognizable token"` |
+| `malformed_jwt` | Token could not be decoded as a JWT | `{app="gateway"} \|= "Malformed JWT"` |
+| `disallowed_issuer` | Token `iss` claim does not match `allowed_iss` | `{app="gateway"} \|= "disallowed issuer"` |
+| `unexpected_algorithm` | Token `alg` header does not match configured `algorithm` | `{app="gateway"} \|= "unexpected algorithm"` |
+| `claims_validation_failed` | Registered claims (`exp`, `nbf`) failed verification | `{app="gateway"} \|= "claims validation failed"` |
+| `max_expiration_exceeded` | Token lifetime exceeds `maximum_expiration` | `{app="gateway"} \|= "maximum expiration"` |
 
 ### unique-app-repo-auth
 
@@ -97,12 +97,12 @@ Default metric name: `unique_app_repo_auth_security_warnings_total`
 
 Possible `reason` label values:
 
-| reason | description |
-|--------|-------------|
-| `api_key_validation_failed` | App repository returned a non-200 response for the API key |
-| `multiple_tokens` | More than one token was found in the request |
-| `unrecognizable_token_type` | Token is neither a string nor a table |
-| `missing_required_headers` | `x-app-id` or `x-company-id` header is absent |
+| reason | description | log query |
+|--------|-------------|-----------|
+| `api_key_validation_failed` | App repository returned a non-200 response for the API key | `{app="gateway"} \|= "API key validation"` |
+| `multiple_tokens` | More than one token was found in the request | `{app="gateway"} \|= "Multiple tokens"` |
+| `unrecognizable_token_type` | Token is neither a string nor a table | `{app="gateway"} \|= "Unrecognizable token"` |
+| `missing_required_headers` | `x-app-id` or `x-company-id` header is absent | `{app="gateway"} \|= "missing required headers"` |
 
 ### Example output
 

--- a/charts/kong-plugins/files/unique-jwt-auth/handler.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/handler.lua
@@ -21,7 +21,10 @@ local counters = {}
 local function get_client_ip()
     local xff = kong.request.get_header("X-Forwarded-For")
     if xff then
-        return xff:match("^%s*([^,%s]+)")
+        local ip = xff:match("^%s*([^,%s]+)")
+        if ip then
+            return ip
+        end
     end
     return kong.client.get_forwarded_ip() or kong.client.get_ip() or "unknown"
 end

--- a/charts/kong-plugins/files/unique-jwt-auth/handler.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/handler.lua
@@ -18,6 +18,14 @@ local re_gmatch = ngx.re.gmatch
 
 local counters = {}
 
+local function get_client_ip()
+    local xff = kong.request.get_header("X-Forwarded-For")
+    if xff then
+        return xff:match("^%s*([^,%s]+)")
+    end
+    return kong.client.get_forwarded_ip() or kong.client.get_ip() or "unknown"
+end
+
 local function inc_warn(conf, reason)
     if not _exporter_ok then
         return
@@ -139,7 +147,7 @@ local function custom_validate_token_signature(conf, jwt, matched_iss, second_ca
         return custom_validate_token_signature(conf, jwt, matched_iss, true)
     end
 
-    kong.log.warn("Rejected token with invalid signature for issuer: " .. matched_iss .. " from " .. (kong.client.get_forwarded_ip() or "unknown"))
+    kong.log.warn("Rejected token with invalid signature for issuer: " .. matched_iss .. " from " .. get_client_ip())
     inc_warn(conf, "invalid_signature")
     return kong.response.exit(401, {
         message = "Unauthorized"
@@ -404,14 +412,14 @@ local function do_authentication(conf)
                 message = "Unauthorized"
             }
         elseif token_type == "table" then
-            kong.log.warn("Multiple tokens provided in request from " .. (kong.client.get_forwarded_ip() or "unknown"))
+            kong.log.warn("Multiple tokens provided in request from " .. get_client_ip())
             inc_warn(conf, "multiple_tokens")
             return false, {
                 status = 401,
                 message = "Unauthorized"
             }
         else
-            kong.log.warn("Unrecognizable token type from " .. (kong.client.get_forwarded_ip() or "unknown"))
+            kong.log.warn("Unrecognizable token type from " .. get_client_ip())
             inc_warn(conf, "unrecognizable_token_type")
             return false, {
                 status = 401,
@@ -423,7 +431,7 @@ local function do_authentication(conf)
     -- Decode token to find out who the consumer is
     local jwt, err = jwt_decoder:new(token)
     if err then
-        kong.log.warn("Malformed JWT received from " .. (kong.client.get_forwarded_ip() or "unknown") .. ": " .. tostring(err))
+        kong.log.warn("Malformed JWT received from " .. get_client_ip() .. ": " .. tostring(err))
         inc_warn(conf, "malformed_jwt")
         return false, {
             status = 401,
@@ -439,7 +447,7 @@ local function do_authentication(conf)
     -- Verify that the issuer is allowed
     local matched_iss = validate_issuer(conf.allowed_iss, jwt.claims)
     if not matched_iss then
-        kong.log.warn("Rejected token with disallowed issuer: " .. tostring(claims.iss) .. " from " .. (kong.client.get_forwarded_ip() or "unknown"))
+        kong.log.warn("Rejected token with disallowed issuer: " .. tostring(claims.iss) .. " from " .. get_client_ip())
         inc_warn(conf, "disallowed_issuer")
         return false, {
             status = 401,
@@ -451,7 +459,7 @@ local function do_authentication(conf)
 
     -- Verify "alg"
     if jwt.header.alg ~= algorithm then
-        kong.log.warn("Rejected token with unexpected algorithm: " .. tostring(jwt.header.alg) .. " (expected " .. algorithm .. ") from " .. (kong.client.get_forwarded_ip() or "unknown"))
+        kong.log.warn("Rejected token with unexpected algorithm: " .. tostring(jwt.header.alg) .. " (expected " .. algorithm .. ") from " .. get_client_ip())
         inc_warn(conf, "unexpected_algorithm")
         return false, {
             status = 403,
@@ -468,7 +476,7 @@ local function do_authentication(conf)
     -- Verify the JWT registered claims
     local ok_claims, errors = jwt:verify_registered_claims(conf.claims_to_verify)
     if not ok_claims then
-        kong.log.warn("Token claims validation failed from " .. (kong.client.get_forwarded_ip() or "unknown") .. ": " .. custom_helper_table_to_string(errors))
+        kong.log.warn("Token claims validation failed from " .. get_client_ip() .. ": " .. custom_helper_table_to_string(errors))
         local reason = "claims_validation_failed"
         if type(errors) == "table" and errors.exp and tostring(errors.exp):find("expired") then
             reason = "token_expired"
@@ -484,7 +492,7 @@ local function do_authentication(conf)
     if conf.maximum_expiration ~= nil and conf.maximum_expiration > 0 then
         local ok, errors = jwt:check_maximum_expiration(conf.maximum_expiration)
         if not ok then
-            kong.log.warn("Token maximum expiration check failed from " .. (kong.client.get_forwarded_ip() or "unknown") .. ": " .. custom_helper_table_to_string(errors))
+            kong.log.warn("Token maximum expiration check failed from " .. get_client_ip() .. ": " .. custom_helper_table_to_string(errors))
             inc_warn(conf, "max_expiration_exceeded")
             return false, {
                 status = 403,


### PR DESCRIPTION
## Describe your changes

## Summary

- Fix `unique-jwt-auth` plugin to log the real client IP instead of the Azure Application Gateway's internal IP. Adds a `get_client_ip()` helper that reads the first entry from `X-Forwarded-For` (set by App Gateway to the originating client) and falls back to `get_forwarded_ip()` / `get_ip()`.
- Add a `log query` column to the security-warning reason tables in the docs for both `unique-jwt-auth` and `unique-app-repo-auth`, giving ready-to-use Loki filter expressions per reason code.

## Checklist before requesting a review
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/helm-charts/blob/main/CONTRIBUTING.md) read and understood
- [x] Chart version bumped (`Chart.yaml`) <!-- Respect proper [semver](https://semver.org)  -->
- [x] Values schema updated (`values.schema.json`) <!-- Chart installation/templating will fail if not changed at deploy time, add a Unit or CI Test to ensure your changes work end to end -->
- [x] Changes updated in [ArtifactHub syntax](https://artifacthub.io/docs/topics/annotations/helm) (`Chart.yaml`) <!-- Changes are incremental, delete all previous changes and don't repeat the change type in the message -->
- [x] Pre-Commit passed or has been run manually (`Makefile`)
