### PR TITLE
chore(agent-sandbox-controller): bump to upstream v0.4.6

### DIFF
--- a/charts/agent-sandbox-controller/Chart.yaml
+++ b/charts/agent-sandbox-controller/Chart.yaml
@@ -8,8 +8,8 @@ name: agent-sandbox-controller
 sources:
   - https://github.com/Unique-AG/helm-charts/tree/main/charts/agent-sandbox-controller
   - https://github.com/kubernetes-sigs/agent-sandbox
-version: 0.4.5-rc.1
-appVersion: "v0.4.5"
+version: 0.4.6-rc.1
+appVersion: "v0.4.6"
 description: |
   Helm chart for the Agent Sandbox controller — a Kubernetes CRD and controller for managing isolated, stateful, singleton workloads (e.g. AI agent runtimes).
 

--- a/charts/agent-sandbox-controller/README.md
+++ b/charts/agent-sandbox-controller/README.md
@@ -4,14 +4,14 @@ Helm chart for the Agent Sandbox controller — a Kubernetes CRD and controller 
 
 Upstream project: https://github.com/kubernetes-sigs/agent-sandbox
 
-![Version: 0.4.5-rc.1](https://img.shields.io/badge/Version-0.4.5--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.5](https://img.shields.io/badge/AppVersion-v0.4.5-informational?style=flat-square)
+![Version: 0.4.6-rc.1](https://img.shields.io/badge/Version-0.4.6--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.6](https://img.shields.io/badge/AppVersion-v0.4.6-informational?style=flat-square)
 
 ## Installation
 
 Releases are published as OCI artifacts to GHCR.
 
 ```sh
-helm install my-agent-sandbox-controller oci://ghcr.io/unique-ag/helm-charts/agent-sandbox-controller --version 0.4.5-rc.1
+helm install my-agent-sandbox-controller oci://ghcr.io/unique-ag/helm-charts/agent-sandbox-controller --version 0.4.6-rc.1
 ```
 
 ## Implementation Details
@@ -44,8 +44,8 @@ The Python SDK tunnel mode auto-discovers a service named `sandbox-router-svc`. 
 | extensions | object | `{"enabled":true}` | Enable the upstream sandbox extensions controller (`SandboxClaim`, `SandboxTemplate`, `SandboxWarmPool`). |
 | extensions.enabled | bool | `true` | Toggle the extensions controller and its RBAC. |
 | fullnameOverride | string | `""` | This is to override the full name. |
-| image | object | `{"digest":"sha256:64317cf5694991d9d63ce6a1b3fda16dfeecca0f01c863945cbcdb38ccc18473","pullPolicy":"IfNotPresent","repository":"registry.k8s.io/agent-sandbox/agent-sandbox-controller","tag":""}` | Container image used by the controller. |
-| image.digest | string | `"sha256:64317cf5694991d9d63ce6a1b3fda16dfeecca0f01c863945cbcdb38ccc18473"` | Pin a specific image by digest. Recommended for supply-chain integrity. |
+| image | object | `{"digest":"sha256:93c28f724f34845fcfbd58818959958fd877f9953698c920add3081f61a54429","pullPolicy":"IfNotPresent","repository":"registry.k8s.io/agent-sandbox/agent-sandbox-controller","tag":""}` | Container image used by the controller. |
+| image.digest | string | `"sha256:93c28f724f34845fcfbd58818959958fd877f9953698c920add3081f61a54429"` | Pin a specific image by digest. Recommended for supply-chain integrity. |
 | image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for images. |
 | image.repository | string | `"registry.k8s.io/agent-sandbox/agent-sandbox-controller"` | This sets the image repository. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
@@ -55,15 +55,15 @@ The Python SDK tunnel mode auto-discovers a service named `sandbox-router-svc`. 
 | podSecurityContext | object | `{"fsGroup":65532,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level security context applied to the controller pod. |
 | replicaCount | int | `1` | Number of controller replicas. Leader election is used to elect a single active leader. |
 | resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Controller container resource requests and limits. |
-| router | object | `{"containerPort":8080,"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000},"enabled":true,"image":{"digest":"sha256:2a3a21a5055051109c7ac8230d3d1c83d7f5f50279ae2c669433bb4d16a93e19","pullPolicy":"IfNotPresent","repository":"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router","tag":"v20260506-v0.4.5"},"livenessProbe":{"initialDelaySeconds":10,"path":"/healthz","periodSeconds":10},"networkPolicy":{"egress":{"sandboxNamespaceSelector":{},"sandboxPort":8888},"enabled":true,"ingress":{"allowedCIDRs":[],"allowedSources":[]}},"podSecurityContext":{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}},"proxyTimeoutSeconds":180,"readinessProbe":{"initialDelaySeconds":5,"path":"/healthz","periodSeconds":5},"replicaCount":2,"resources":{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"service":{"name":"","port":8080,"type":"ClusterIP"},"topologySpreadConstraints":{"enabled":true,"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}}` | Sandbox router subchart configuration. The router proxies traffic to sandbox pods and is required for the Python SDK tunnel mode. |
+| router | object | `{"containerPort":8080,"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000},"enabled":true,"image":{"digest":"sha256:15213198b19cf4da2ad560d84a6e144a1ed79edaf058f806c5438bc5142b7058","pullPolicy":"IfNotPresent","repository":"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router","tag":"v20260514-v0.4.6"},"livenessProbe":{"initialDelaySeconds":10,"path":"/healthz","periodSeconds":10},"networkPolicy":{"egress":{"sandboxNamespaceSelector":{},"sandboxPort":8888},"enabled":true,"ingress":{"allowedCIDRs":[],"allowedSources":[]}},"podSecurityContext":{"fsGroup":1000,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}},"proxyTimeoutSeconds":180,"readinessProbe":{"initialDelaySeconds":5,"path":"/healthz","periodSeconds":5},"replicaCount":2,"resources":{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"service":{"name":"","port":8080,"type":"ClusterIP"},"topologySpreadConstraints":{"enabled":true,"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"ScheduleAnyway"}}` | Sandbox router subchart configuration. The router proxies traffic to sandbox pods and is required for the Python SDK tunnel mode. |
 | router.containerPort | int | `8080` | Container port the router listens on inside the pod. |
 | router.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1000,"runAsNonRoot":true,"runAsUser":1000}` | Container-level security context applied to the router container. |
 | router.enabled | bool | `true` | Toggle the sandbox router deployment, service, and network policy. |
-| router.image | object | `{"digest":"sha256:2a3a21a5055051109c7ac8230d3d1c83d7f5f50279ae2c669433bb4d16a93e19","pullPolicy":"IfNotPresent","repository":"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router","tag":"v20260506-v0.4.5"}` | Container image used by the router. |
-| router.image.digest | string | `"sha256:2a3a21a5055051109c7ac8230d3d1c83d7f5f50279ae2c669433bb4d16a93e19"` | Pin a specific router image by digest. |
+| router.image | object | `{"digest":"sha256:15213198b19cf4da2ad560d84a6e144a1ed79edaf058f806c5438bc5142b7058","pullPolicy":"IfNotPresent","repository":"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router","tag":"v20260514-v0.4.6"}` | Container image used by the router. |
+| router.image.digest | string | `"sha256:15213198b19cf4da2ad560d84a6e144a1ed79edaf058f806c5438bc5142b7058"` | Pin a specific router image by digest. |
 | router.image.pullPolicy | string | `"IfNotPresent"` | This sets the pull policy for the router image. |
 | router.image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router"` | This sets the router image repository. |
-| router.image.tag | string | `"v20260506-v0.4.5"` | Overrides the router image tag. |
+| router.image.tag | string | `"v20260514-v0.4.6"` | Overrides the router image tag. |
 | router.livenessProbe | object | `{"initialDelaySeconds":10,"path":"/healthz","periodSeconds":10}` | HTTP liveness probe configuration for the router. |
 | router.networkPolicy | object | `{"egress":{"sandboxNamespaceSelector":{},"sandboxPort":8888},"enabled":true,"ingress":{"allowedCIDRs":[],"allowedSources":[]}}` | `NetworkPolicy` for the router pod. |
 | router.networkPolicy.egress | object | `{"sandboxNamespaceSelector":{},"sandboxPort":8888}` | Egress rules. By default the router needs to reach DNS and sandbox pods. |

--- a/charts/agent-sandbox-controller/crds/crds.yaml
+++ b/charts/agent-sandbox-controller/crds/crds.yaml
@@ -3835,6 +3835,8 @@ spec:
                 maximum: 1
                 minimum: 0
                 type: integer
+              service:
+                type: boolean
               shutdownPolicy:
                 default: Retain
                 enum:
@@ -8191,6 +8193,8 @@ spec:
                 required:
                 - spec
                 type: object
+              service:
+                type: boolean
               volumeClaimTemplates:
                 items:
                   properties:

--- a/charts/agent-sandbox-controller/values.yaml
+++ b/charts/agent-sandbox-controller/values.yaml
@@ -15,7 +15,7 @@ image:
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
   # -- Pin a specific image by digest. Recommended for supply-chain integrity.
-  digest: sha256:64317cf5694991d9d63ce6a1b3fda16dfeecca0f01c863945cbcdb38ccc18473
+  digest: sha256:93c28f724f34845fcfbd58818959958fd877f9953698c920add3081f61a54429
   # -- This sets the pull policy for images.
   pullPolicy: IfNotPresent
 
@@ -85,9 +85,9 @@ router:
     # -- This sets the router image repository.
     repository: us-central1-docker.pkg.dev/k8s-staging-images/agent-sandbox/sandbox-router
     # -- Overrides the router image tag.
-    tag: v20260506-v0.4.5
+    tag: v20260514-v0.4.6
     # -- Pin a specific router image by digest.
-    digest: sha256:2a3a21a5055051109c7ac8230d3d1c83d7f5f50279ae2c669433bb4d16a93e19
+    digest: sha256:15213198b19cf4da2ad560d84a6e144a1ed79edaf058f806c5438bc5142b7058
     # -- This sets the pull policy for the router image.
     pullPolicy: IfNotPresent
   # -- Router `Service` settings.


### PR DESCRIPTION
## Describe your changes

Bumps the `agent-sandbox-controller` chart to track upstream [`kubernetes-sigs/agent-sandbox` v0.4.6](https://github.com/kubernetes-sigs/agent-sandbox/releases/tag/v0.4.6).

| Item | From | To |
|------|------|-----|
| `appVersion` | `v0.4.5` | `v0.4.6` |
| Chart `version` | `0.4.5-rc.1` | `0.4.6-rc.1` |
| Controller image digest | `sha256:64317cf5…ccc18473` | `sha256:93c28f72…61a54429` |
| Router image tag | `v20260506-v0.4.5` | `v20260514-v0.4.6` |
| Router image digest | `sha256:2a3a21a5…16a93e19` | `sha256:15213198…142b7058` |

### Changes

- Sync CRDs (`crds/crds.yaml`) from the upstream v0.4.6 `manifest.yaml` + `extensions.yaml` release artifacts. Only schema addition: `service: boolean` on `Sandbox.spec` and `SandboxTemplate.spec.podTemplate` (opt-out of the per-sandbox headless service).
- No upstream RBAC changes between v0.4.5 and v0.4.6 (verified against both release manifests).
- Regenerate `README.md` via `helm-docs` (1.14.2).

### Why

The v0.4.6 router honors the `X-Sandbox-Pod-IP` header that the `k8s-agent-sandbox` 0.4.6 Python client already sends, routing turns directly to the pod IP instead of the per-sandbox headless-service DNS name. This removes the post-ready NXDOMAIN tail (endpoint publication lag + up to 30s CoreDNS negative caching) that showed up as router 502 retries on QA (UN-23315). Verified the pod-IP routing commit (`636e032`) is an ancestor of the upstream `v0.4.6` tag.

Image digests match `crane digest` of the upstream tags.

## Checklist before requesting a review
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/helm-charts/blob/main/CONTRIBUTING.md) read and understood
- [x] Chart version bumped (`Chart.yaml`)
- [x] Values schema updated (`values.schema.json`) — n/a, chart has no schema file
- [x] Changes updated in [ArtifactHub syntax](https://artifacthub.io/docs/topics/annotations/helm) (`Chart.yaml`) — n/a, chart does not use the `changes` annotation
- [x] Pre-Commit passed (helm-docs, helm-lint) and `helm unittest` 9/9 green

Refs: UN-23315