### PR TITLE
feat(kong-plugins): single-use opaque WebSocket tickets backed by Redis [UN-20091]

### DIFF
--- a/.github/workflows/charts.lint-and-test.yaml
+++ b/.github/workflows/charts.lint-and-test.yaml
@@ -98,3 +98,12 @@ jobs:
       - name: Run chart-testing (install)
         run: ct install --config ./.github/configs/ct-install.yaml
         if: steps.list-changed.outputs.changed == 'true'
+
+  kong-plugin-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run unique-jwt-auth plugin specs
+        run: ./charts/kong-plugins/tests/unique-jwt-auth/run.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,16 @@ The linting can be invoked manually with the following command:
 ./scripts/lint.sh
 ```
 
+### Testing kong-plugins Lua specs
+
+`ct` only renders the ConfigMaps that carry the Lua plugins; it never executes them. The `unique-jwt-auth` specs run inside the pinned Kong image against a real Redis container:
+
+```shell
+./charts/kong-plugins/tests/unique-jwt-auth/run.sh
+```
+
+CI runs the same script as the `kong-plugin-test` job. Image digests are pinned in `run.sh`; bump tag and digest together when moving Kong or Redis versions.
+
 ### Locally installing charts
 
 Refer to [LOCAL.md](./LOCAL.md) for instructions on how to test charts locally as this is not mandatory for a Contribution. The CI will take care that the charts in their default version are always installable.

--- a/charts/kong-plugins/Chart.yaml
+++ b/charts/kong-plugins/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: unique-ag
     url: https://unique.ch/
 name: kong-plugins
-version: 2.4.0
+version: 2.5.0
 description: |
   The 'kong-plugins' chart provides a streamlined solution for deploying Kong plugins via ConfigMaps to be used with the Unique Software.
 
@@ -15,4 +15,4 @@ description: |
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: log a redacted token fingerprint (sha256, length, segment shape) on malformed JWTs so KongJwtAuthMalformedJwt can be triaged without logging the raw token
+      description: mint single-use opaque WebSocket upgrade tickets stored hash-only in Redis (?ticket=), while the existing ?token= path stays unchanged when ws_ticket_enabled is off

--- a/charts/kong-plugins/README.md
+++ b/charts/kong-plugins/README.md
@@ -93,10 +93,10 @@ Browsers cannot set an `Authorization` header on a WebSocket handshake, so clien
 | `redis_password` | — | `referenceable` + `encrypted` (Kong vault). |
 | `redis_ssl` / `redis_ssl_verify` | `false` / `true` | TLS to Redis. |
 | `redis_timeout_ms` | `2000` | Connect/read timeout. |
-| `redis_database` | `0` | Logical Redis DB. |
+| `redis_database` | `7` | Logical Redis DB. Claimed in the monorepo Redis registry (`infrastructure/redis.md`). Redis Cluster has no `SELECT` — set `0` and rely on `redis_key_prefix` for isolation. |
 | `redis_key_prefix` | `ws_ticket:` | Key prefix for ticket records and rate-limit counters. |
 
-Redis is required across replicas: `kong.cache` and `lua_shared_dict` are per-pod and cannot enforce single-use. Mint and consume **fail closed** (503) if Redis is unreachable.
+Redis is required across replicas: `kong.cache` and `lua_shared_dict` are per-pod and cannot enforce single-use. Mint and consume **fail closed** (503) if Redis is unreachable. Pick the logical DB from the monorepo Redis registry; DB `7` is registered for Kong WebSocket tickets.
 
 **Example** (enable per WebSocket route after Redis is provisioned):
 

--- a/charts/kong-plugins/README.md
+++ b/charts/kong-plugins/README.md
@@ -6,7 +6,7 @@ Refer to each plugins readme section to learn more about them.
 
 Please report any security concerns with the plugins via the [Security Policy](https://github.com/Unique-AG/helm-charts/tree/main?tab=security-ov-file).
 
-![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Implementation Details
 
@@ -15,7 +15,7 @@ Please report any security concerns with the plugins via the [Security Policy](h
 New releases are published as OCI artifacts only. The Helm repository index is frozen and will not receive new versions—see the [repository README](https://github.com/Unique-AG/helm-charts/blob/main/README.md#migrating-to-oci) for migration steps.
 
 ```sh
-helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --version 2.4.0
+helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --version 2.5.0
 ```
 
 <details>
@@ -23,7 +23,7 @@ helm install my-kong-plugins oci://ghcr.io/unique-ag/helm-charts/kong-plugins --
 
 ```sh
 helm repo add unique https://unique-ag.github.io/helm-charts/
-helm install my-kong-plugins unique/kong-plugins --version 2.4.0
+helm install my-kong-plugins unique/kong-plugins --version 2.5.0
 ```
 
 </details>
@@ -70,6 +70,57 @@ config:
 
 With this configuration, both external clients (e.g., browser users) and the internal JWT validation plugin can utilize the same identity provider (IdP) for token issuance and validation without requiring further customization.
 
+#### Single-use WebSocket tickets (Redis)
+
+Browsers cannot set an `Authorization` header on a WebSocket handshake, so clients often put a credential in the query string. When `ws_ticket_enabled` is true, the plugin can exchange a normal Zitadel JWT for a short-lived opaque ticket and accept that ticket on the upgrade:
+
+1. `POST /auth/ticket` with `Authorization: Bearer <access token>` — plugin verifies the JWT (same checks as the normal path), stores `sha256(ticket)` in Redis with identity + scope + TTL, returns `{ticket, expires_in}`. Never proxied upstream. The access token is never stored.
+2. `GET …?ticket=…` with `Upgrade: websocket` — plugin atomically retrieves and deletes the hash (Redis `EVAL`), stamps `x-user-id` / `x-company-id`, strips the query parameter, proxies the upgrade.
+
+`?token=` (and cookie / `Authorization`) keep working unchanged. The ticket path is selected only when `?ticket=` is present; there is no fallback to the token path on a bad ticket.
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `ws_ticket_enabled` | `false` | Master switch. Off = identical to previous behaviour. |
+| `ticket_param_name` | `ticket` | Query parameter for the opaque ticket. |
+| `ticket_mint_path` | `/auth/ticket` | Path answered by the plugin for minting. |
+| `ticket_ttl` | `20` | Ticket lifetime in seconds (5–60). |
+| `ticket_scope` | — | Route/service binding written into the record and checked on consume. Required when enabled. |
+| `ticket_allowed_origins` | `[]` | Exact Origin allowlist on consume. Empty = not enforced. |
+| `ticket_mint_rate_limit` | `60` | Max mints per subject per 60s. `0` disables. |
+| `ticket_fail_rate_limit` | `30` | Max failed consumptions per IP per 60s. `0` disables. |
+| `redis_host` / `redis_port` | — / `6379` | Redis endpoint reachable from every Kong replica. |
+| `redis_password` | — | `referenceable` + `encrypted` (Kong vault). |
+| `redis_ssl` / `redis_ssl_verify` | `false` / `true` | TLS to Redis. |
+| `redis_timeout_ms` | `2000` | Connect/read timeout. |
+| `redis_database` | `0` | Logical Redis DB. |
+| `redis_key_prefix` | `ws_ticket:` | Key prefix for ticket records and rate-limit counters. |
+
+Redis is required across replicas: `kong.cache` and `lua_shared_dict` are per-pod and cannot enforce single-use. Mint and consume **fail closed** (503) if Redis is unreachable.
+
+**Example** (enable per WebSocket route after Redis is provisioned):
+
+```yaml
+apiVersion: configuration.konghq.com/v1
+kind: KongClusterPlugin
+plugin: unique-jwt-auth
+config:
+  allowed_iss:
+    - https://id.example.com
+  uri_param_names:
+    - token
+  zitadel_project_id: '<ZITADEL_PROJECT_ID>'
+  ws_ticket_enabled: true
+  ticket_scope: ws:graphql
+  ticket_allowed_origins:
+    - https://app.example.com
+  redis_host: redis.kong-system.svc.cluster.local
+  redis_port: 6379
+  redis_password: '{vault://env/kong-ws-ticket-redis-password}'
+```
+
+Rollout: deploy with the flag off (no behaviour change) → provision Redis and enable per tenant → migrate clients from `?token=` to `?ticket=` at their own pace. Redact the ticket query parameter in ingress, WAF, and tracing logs (the plugin strips it from the upstream request only).
+
 ## Prometheus Metrics
 
 Both plugins expose a single Prometheus counter for security warning events when Kong's [Prometheus plugin](https://docs.konghq.com/hub/kong-inc/prometheus/) is enabled. Each rejection that produces a `WARN` log increments the counter with a `reason` label that identifies the failure type.
@@ -93,6 +144,12 @@ Possible `reason` label values:
 | `unexpected_algorithm` | Token `alg` header does not match configured `algorithm` |
 | `claims_validation_failed` | Registered claims (`exp`, `nbf`) failed verification |
 | `max_expiration_exceeded` | Token lifetime exceeds `maximum_expiration` |
+| `token_expired` | Token `exp` claim indicates expiry |
+| `ws_ticket_unknown` | Ticket missing, expired, replayed, or presented outside an upgrade |
+| `ws_ticket_scope_mismatch` | Ticket presented on a different route/service than minted for |
+| `ws_ticket_origin_rejected` | Upgrade Origin missing or not on the exact allowlist |
+| `ws_ticket_mint_rate_limited` | Subject exceeded `ticket_mint_rate_limit` |
+| `ws_ticket_redis_error` | Redis unreachable or errored during mint/consume (fail-closed) |
 
 ### unique-app-repo-auth
 
@@ -128,7 +185,7 @@ The metric will be exposed as `kong_my_custom_auth_warnings_total`.
 
 ### Alerts
 
-The chart ships one `PrometheusRule` alert per rejection reason for both plugins — 12 alerts in total — enabled by default when the `monitoring.coreos.com/v1` CRD is present and `prometheus.enabled` is `true`. Each alert fires when total occurrences across gateway pods within a 5-minute window exceed a configurable threshold (`sum(increase(...[5m])) > threshold`). The default threshold is 2 for most alerts and 50 for `KongAppRepoAuthApiKeyValidationFailed` (since individual API key failures are expected).
+The chart ships one `PrometheusRule` alert per rejection reason for both plugins — 18 alerts in total — enabled by default when the `monitoring.coreos.com/v1` CRD is present and `prometheus.enabled` is `true`. Each alert fires when total occurrences across gateway pods within a 5-minute window exceed a configurable threshold (`sum(increase(...[5m])) > threshold`). The default threshold is 2 for most alerts and 50 for `KongAppRepoAuthApiKeyValidationFailed` (since individual API key failures are expected).
 
 Expiration-related alerts are **disabled by default** since token expiry is a normal operational event.
 
@@ -143,7 +200,13 @@ Expiration-related alerts are **disabled by default** since token expiry is a no
 | `KongJwtAuthMultipleTokens` | `multiple_tokens` | warning | yes |
 | `KongJwtAuthUnrecognizableTokenType` | `unrecognizable_token_type` | warning | yes |
 | `KongJwtAuthClaimsValidationFailed` | `claims_validation_failed` | warning | **no** |
+| `KongJwtAuthTokenExpired` | `token_expired` | warning | **no** |
 | `KongJwtAuthMaxExpirationExceeded` | `max_expiration_exceeded` | warning | **no** |
+| `KongJwtAuthWsTicketUnknown` | `ws_ticket_unknown` | warning | yes |
+| `KongJwtAuthWsTicketScopeMismatch` | `ws_ticket_scope_mismatch` | critical | yes |
+| `KongJwtAuthWsTicketOriginRejected` | `ws_ticket_origin_rejected` | warning | yes |
+| `KongJwtAuthWsTicketMintRateLimited` | `ws_ticket_mint_rate_limited` | warning | yes |
+| `KongJwtAuthWsTicketRedisError` | `ws_ticket_redis_error` | critical | yes |
 
 #### unique-app-repo-auth alerts
 
@@ -247,12 +310,12 @@ When `config.ssl_verify` is `true` (the default), the `jwks_uri` returned from t
 | appRepoAuth.name | string | `"kong-plugin-unique-app-repo-auth"` | The name of the app repository auth config map |
 | jwtAuth | object | `{"name":"kong-plugin-unique-jwt-auth"}` | jwtAuth enables the jwt-auth plugin |
 | jwtAuth.name | string | `"kong-plugin-unique-jwt-auth"` | The name of the jwt auth config map |
-| prometheus.defaultAlerts.securityWarnings | object | `{"additionalLabels":{},"appRepoAuthMetricName":"kong_unique_app_repo_auth_security_warnings_total","enabled":true,"jwtAuthMetricName":"kong_unique_jwt_auth_security_warnings_total","rules":{"KongAppRepoAuthApiKeyValidationFailed":{"enabled":true,"for":"5m","interval":"5m","severity":"warning","threshold":50},"KongAppRepoAuthMissingRequiredHeaders":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongAppRepoAuthMultipleTokens":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongAppRepoAuthUnrecognizableTokenType":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthClaimsValidationFailed":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthDisallowedIssuer":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthInvalidSignature":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":5},"KongJwtAuthMalformedJwt":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthMaxExpirationExceeded":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthMultipleTokens":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthTokenExpired":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthUnexpectedAlgorithm":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthUnrecognizableTokenType":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10}}}` | securityWarnings alerts fire on the counters emitted by the kong plugins for each WARN-level security rejection. |
+| prometheus.defaultAlerts.securityWarnings | object | `{"additionalLabels":{},"appRepoAuthMetricName":"kong_unique_app_repo_auth_security_warnings_total","enabled":true,"jwtAuthMetricName":"kong_unique_jwt_auth_security_warnings_total","rules":{"KongAppRepoAuthApiKeyValidationFailed":{"enabled":true,"for":"5m","interval":"5m","severity":"warning","threshold":50},"KongAppRepoAuthMissingRequiredHeaders":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongAppRepoAuthMultipleTokens":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongAppRepoAuthUnrecognizableTokenType":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthClaimsValidationFailed":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthDisallowedIssuer":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthInvalidSignature":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":5},"KongJwtAuthMalformedJwt":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthMaxExpirationExceeded":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthMultipleTokens":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthTokenExpired":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthUnexpectedAlgorithm":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthUnrecognizableTokenType":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthWsTicketMintRateLimited":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthWsTicketOriginRejected":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthWsTicketRedisError":{"enabled":true,"for":"1m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthWsTicketScopeMismatch":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthWsTicketUnknown":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":5}}}` | securityWarnings alerts fire on the counters emitted by the kong plugins for each WARN-level security rejection. |
 | prometheus.defaultAlerts.securityWarnings.additionalLabels | object | `{}` | Extra labels added to the PrometheusRule metadata and each alert's labels. |
 | prometheus.defaultAlerts.securityWarnings.appRepoAuthMetricName | string | `"kong_unique_app_repo_auth_security_warnings_total"` | Base metric name (without kong_ prefix) used in PromQL for the app-repo-auth plugin. Must match config.security_warning_metric_name on the KongClusterPlugin. |
 | prometheus.defaultAlerts.securityWarnings.enabled | bool | `true` | Enable the security warnings alert group. Requires monitoring.coreos.com/v1 CRDs. |
 | prometheus.defaultAlerts.securityWarnings.jwtAuthMetricName | string | `"kong_unique_jwt_auth_security_warnings_total"` | Base metric name (without kong_ prefix) used in PromQL for the jwt-auth plugin. Must match config.security_warning_metric_name on the KongClusterPlugin. |
-| prometheus.defaultAlerts.securityWarnings.rules | object | `{"KongAppRepoAuthApiKeyValidationFailed":{"enabled":true,"for":"5m","interval":"5m","severity":"warning","threshold":50},"KongAppRepoAuthMissingRequiredHeaders":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongAppRepoAuthMultipleTokens":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongAppRepoAuthUnrecognizableTokenType":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthClaimsValidationFailed":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthDisallowedIssuer":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthInvalidSignature":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":5},"KongJwtAuthMalformedJwt":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthMaxExpirationExceeded":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthMultipleTokens":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthTokenExpired":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthUnexpectedAlgorithm":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthUnrecognizableTokenType":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10}}` | Per-alert configuration. Each entry controls enabled, severity, for, threshold (number of occurrences in interval), and interval (PromQL range window). |
+| prometheus.defaultAlerts.securityWarnings.rules | object | `{"KongAppRepoAuthApiKeyValidationFailed":{"enabled":true,"for":"5m","interval":"5m","severity":"warning","threshold":50},"KongAppRepoAuthMissingRequiredHeaders":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongAppRepoAuthMultipleTokens":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongAppRepoAuthUnrecognizableTokenType":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthClaimsValidationFailed":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthDisallowedIssuer":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthInvalidSignature":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":5},"KongJwtAuthMalformedJwt":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthMaxExpirationExceeded":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthMultipleTokens":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthTokenExpired":{"enabled":false,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthUnexpectedAlgorithm":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthUnrecognizableTokenType":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthWsTicketMintRateLimited":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":10},"KongJwtAuthWsTicketOriginRejected":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":2},"KongJwtAuthWsTicketRedisError":{"enabled":true,"for":"1m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthWsTicketScopeMismatch":{"enabled":true,"for":"0m","interval":"5m","severity":"critical","threshold":2},"KongJwtAuthWsTicketUnknown":{"enabled":true,"for":"0m","interval":"5m","severity":"warning","threshold":5}}` | Per-alert configuration. Each entry controls enabled, severity, for, threshold (number of occurrences in interval), and interval (PromQL range window). |
 | prometheus.enabled | bool | `true` | Enable Prometheus integration. When false no PrometheusRule resources are rendered. |
 
 ----------------------------------------------

--- a/charts/kong-plugins/README.md
+++ b/charts/kong-plugins/README.md
@@ -75,7 +75,7 @@ With this configuration, both external clients (e.g., browser users) and the int
 Browsers cannot set an `Authorization` header on a WebSocket handshake, so clients often put a credential in the query string. When `ws_ticket_enabled` is true, the plugin can exchange a normal Zitadel JWT for a short-lived opaque ticket and accept that ticket on the upgrade:
 
 1. `POST /auth/ticket` with `Authorization: Bearer <access token>` — plugin verifies the JWT (same checks as the normal path), stores `sha256(ticket)` in Redis with identity + scope + TTL, returns `{ticket, expires_in}`. Never proxied upstream. The access token is never stored.
-2. `GET …?ticket=…` with `Upgrade: websocket` — plugin atomically retrieves and deletes the hash (Redis `EVAL`), stamps `x-user-id` / `x-company-id`, strips the query parameter, proxies the upgrade.
+2. `GET …?ticket=…` with `Upgrade: websocket` — plugin atomically checks scope and retrieves-and-deletes the hash (Redis `EVAL`); a wrong-scope attempt is rejected without consuming the ticket. It then stamps `x-user-id` / `x-company-id`, strips the query parameter, proxies the upgrade.
 
 `?token=` (and cookie / `Authorization`) keep working unchanged. The ticket path is selected only when `?ticket=` is present; there is no fallback to the token path on a bad ticket.
 

--- a/charts/kong-plugins/README.md.gotmpl
+++ b/charts/kong-plugins/README.md.gotmpl
@@ -72,7 +72,7 @@ With this configuration, both external clients (e.g., browser users) and the int
 Browsers cannot set an `Authorization` header on a WebSocket handshake, so clients often put a credential in the query string. When `ws_ticket_enabled` is true, the plugin can exchange a normal Zitadel JWT for a short-lived opaque ticket and accept that ticket on the upgrade:
 
 1. `POST /auth/ticket` with `Authorization: Bearer <access token>` — plugin verifies the JWT (same checks as the normal path), stores `sha256(ticket)` in Redis with identity + scope + TTL, returns `{ticket, expires_in}`. Never proxied upstream. The access token is never stored.
-2. `GET …?ticket=…` with `Upgrade: websocket` — plugin atomically retrieves and deletes the hash (Redis `EVAL`), stamps `x-user-id` / `x-company-id`, strips the query parameter, proxies the upgrade.
+2. `GET …?ticket=…` with `Upgrade: websocket` — plugin atomically checks scope and retrieves-and-deletes the hash (Redis `EVAL`); a wrong-scope attempt is rejected without consuming the ticket. It then stamps `x-user-id` / `x-company-id`, strips the query parameter, proxies the upgrade.
 
 `?token=` (and cookie / `Authorization`) keep working unchanged. The ticket path is selected only when `?ticket=` is present; there is no fallback to the token path on a bad ticket.
 

--- a/charts/kong-plugins/README.md.gotmpl
+++ b/charts/kong-plugins/README.md.gotmpl
@@ -67,6 +67,57 @@ config:
 
 With this configuration, both external clients (e.g., browser users) and the internal JWT validation plugin can utilize the same identity provider (IdP) for token issuance and validation without requiring further customization.
 
+#### Single-use WebSocket tickets (Redis)
+
+Browsers cannot set an `Authorization` header on a WebSocket handshake, so clients often put a credential in the query string. When `ws_ticket_enabled` is true, the plugin can exchange a normal Zitadel JWT for a short-lived opaque ticket and accept that ticket on the upgrade:
+
+1. `POST /auth/ticket` with `Authorization: Bearer <access token>` — plugin verifies the JWT (same checks as the normal path), stores `sha256(ticket)` in Redis with identity + scope + TTL, returns `{ticket, expires_in}`. Never proxied upstream. The access token is never stored.
+2. `GET …?ticket=…` with `Upgrade: websocket` — plugin atomically retrieves and deletes the hash (Redis `EVAL`), stamps `x-user-id` / `x-company-id`, strips the query parameter, proxies the upgrade.
+
+`?token=` (and cookie / `Authorization`) keep working unchanged. The ticket path is selected only when `?ticket=` is present; there is no fallback to the token path on a bad ticket.
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `ws_ticket_enabled` | `false` | Master switch. Off = identical to previous behaviour. |
+| `ticket_param_name` | `ticket` | Query parameter for the opaque ticket. |
+| `ticket_mint_path` | `/auth/ticket` | Path answered by the plugin for minting. |
+| `ticket_ttl` | `20` | Ticket lifetime in seconds (5–60). |
+| `ticket_scope` | — | Route/service binding written into the record and checked on consume. Required when enabled. |
+| `ticket_allowed_origins` | `[]` | Exact Origin allowlist on consume. Empty = not enforced. |
+| `ticket_mint_rate_limit` | `60` | Max mints per subject per 60s. `0` disables. |
+| `ticket_fail_rate_limit` | `30` | Max failed consumptions per IP per 60s. `0` disables. |
+| `redis_host` / `redis_port` | — / `6379` | Redis endpoint reachable from every Kong replica. |
+| `redis_password` | — | `referenceable` + `encrypted` (Kong vault). |
+| `redis_ssl` / `redis_ssl_verify` | `false` / `true` | TLS to Redis. |
+| `redis_timeout_ms` | `2000` | Connect/read timeout. |
+| `redis_database` | `0` | Logical Redis DB. |
+| `redis_key_prefix` | `ws_ticket:` | Key prefix for ticket records and rate-limit counters. |
+
+Redis is required across replicas: `kong.cache` and `lua_shared_dict` are per-pod and cannot enforce single-use. Mint and consume **fail closed** (503) if Redis is unreachable.
+
+**Example** (enable per WebSocket route after Redis is provisioned):
+
+```yaml
+apiVersion: configuration.konghq.com/v1
+kind: KongClusterPlugin
+plugin: unique-jwt-auth
+config:
+  allowed_iss:
+    - https://id.example.com
+  uri_param_names:
+    - token
+  zitadel_project_id: '<ZITADEL_PROJECT_ID>'
+  ws_ticket_enabled: true
+  ticket_scope: ws:graphql
+  ticket_allowed_origins:
+    - https://app.example.com
+  redis_host: redis.kong-system.svc.cluster.local
+  redis_port: 6379
+  redis_password: '{vault://env/kong-ws-ticket-redis-password}'
+```
+
+Rollout: deploy with the flag off (no behaviour change) → provision Redis and enable per tenant → migrate clients from `?token=` to `?ticket=` at their own pace. Redact the ticket query parameter in ingress, WAF, and tracing logs (the plugin strips it from the upstream request only).
+
 ## Prometheus Metrics
 
 Both plugins expose a single Prometheus counter for security warning events when Kong's [Prometheus plugin](https://docs.konghq.com/hub/kong-inc/prometheus/) is enabled. Each rejection that produces a `WARN` log increments the counter with a `reason` label that identifies the failure type.
@@ -90,6 +141,12 @@ Possible `reason` label values:
 | `unexpected_algorithm` | Token `alg` header does not match configured `algorithm` |
 | `claims_validation_failed` | Registered claims (`exp`, `nbf`) failed verification |
 | `max_expiration_exceeded` | Token lifetime exceeds `maximum_expiration` |
+| `token_expired` | Token `exp` claim indicates expiry |
+| `ws_ticket_unknown` | Ticket missing, expired, replayed, or presented outside an upgrade |
+| `ws_ticket_scope_mismatch` | Ticket presented on a different route/service than minted for |
+| `ws_ticket_origin_rejected` | Upgrade Origin missing or not on the exact allowlist |
+| `ws_ticket_mint_rate_limited` | Subject exceeded `ticket_mint_rate_limit` |
+| `ws_ticket_redis_error` | Redis unreachable or errored during mint/consume (fail-closed) |
 
 ### unique-app-repo-auth
 
@@ -125,7 +182,7 @@ The metric will be exposed as `kong_my_custom_auth_warnings_total`.
 
 ### Alerts
 
-The chart ships one `PrometheusRule` alert per rejection reason for both plugins — 12 alerts in total — enabled by default when the `monitoring.coreos.com/v1` CRD is present and `prometheus.enabled` is `true`. Each alert fires when total occurrences across gateway pods within a 5-minute window exceed a configurable threshold (`sum(increase(...[5m])) > threshold`). The default threshold is 2 for most alerts and 50 for `KongAppRepoAuthApiKeyValidationFailed` (since individual API key failures are expected).
+The chart ships one `PrometheusRule` alert per rejection reason for both plugins — 18 alerts in total — enabled by default when the `monitoring.coreos.com/v1` CRD is present and `prometheus.enabled` is `true`. Each alert fires when total occurrences across gateway pods within a 5-minute window exceed a configurable threshold (`sum(increase(...[5m])) > threshold`). The default threshold is 2 for most alerts and 50 for `KongAppRepoAuthApiKeyValidationFailed` (since individual API key failures are expected).
 
 Expiration-related alerts are **disabled by default** since token expiry is a normal operational event.
 
@@ -140,7 +197,13 @@ Expiration-related alerts are **disabled by default** since token expiry is a no
 | `KongJwtAuthMultipleTokens` | `multiple_tokens` | warning | yes |
 | `KongJwtAuthUnrecognizableTokenType` | `unrecognizable_token_type` | warning | yes |
 | `KongJwtAuthClaimsValidationFailed` | `claims_validation_failed` | warning | **no** |
+| `KongJwtAuthTokenExpired` | `token_expired` | warning | **no** |
 | `KongJwtAuthMaxExpirationExceeded` | `max_expiration_exceeded` | warning | **no** |
+| `KongJwtAuthWsTicketUnknown` | `ws_ticket_unknown` | warning | yes |
+| `KongJwtAuthWsTicketScopeMismatch` | `ws_ticket_scope_mismatch` | critical | yes |
+| `KongJwtAuthWsTicketOriginRejected` | `ws_ticket_origin_rejected` | warning | yes |
+| `KongJwtAuthWsTicketMintRateLimited` | `ws_ticket_mint_rate_limited` | warning | yes |
+| `KongJwtAuthWsTicketRedisError` | `ws_ticket_redis_error` | critical | yes |
 
 #### unique-app-repo-auth alerts
 

--- a/charts/kong-plugins/README.md.gotmpl
+++ b/charts/kong-plugins/README.md.gotmpl
@@ -90,10 +90,10 @@ Browsers cannot set an `Authorization` header on a WebSocket handshake, so clien
 | `redis_password` | — | `referenceable` + `encrypted` (Kong vault). |
 | `redis_ssl` / `redis_ssl_verify` | `false` / `true` | TLS to Redis. |
 | `redis_timeout_ms` | `2000` | Connect/read timeout. |
-| `redis_database` | `0` | Logical Redis DB. |
+| `redis_database` | `7` | Logical Redis DB. Claimed in the monorepo Redis registry (`infrastructure/redis.md`). Redis Cluster has no `SELECT` — set `0` and rely on `redis_key_prefix` for isolation. |
 | `redis_key_prefix` | `ws_ticket:` | Key prefix for ticket records and rate-limit counters. |
 
-Redis is required across replicas: `kong.cache` and `lua_shared_dict` are per-pod and cannot enforce single-use. Mint and consume **fail closed** (503) if Redis is unreachable.
+Redis is required across replicas: `kong.cache` and `lua_shared_dict` are per-pod and cannot enforce single-use. Mint and consume **fail closed** (503) if Redis is unreachable. Pick the logical DB from the monorepo Redis registry; DB `7` is registered for Kong WebSocket tickets.
 
 **Example** (enable per WebSocket route after Redis is provisioned):
 

--- a/charts/kong-plugins/files/unique-jwt-auth/handler.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/handler.lua
@@ -4,6 +4,7 @@ local cjson = require "cjson.safe"
 local _exporter_ok, exporter = pcall(require, "kong.plugins.prometheus.exporter")
 
 local zitadel_keys = require "kong.plugins.unique-jwt-auth.zitadel_keys"
+local ws_ticket = require "kong.plugins.unique-jwt-auth.ws_ticket"
 
 local validate_issuer = require"kong.plugins.unique-jwt-auth.validate_issuers".validate_issuer
 
@@ -416,6 +417,85 @@ end
 -- Now again module names which also exist in original "jwt" kong OSS plugin
 -------------------------------------------------------------------------------
 
+-------------------------------------------------------------------------------
+-- Shared Zitadel JWT verification used by the normal auth path and by ticket
+-- minting. Same checks, same order, same error responses — extracted so the
+-- two call sites cannot drift. Does not match consumers or stamp headers.
+--
+-- @return jwt on success; nil, err_table on failure
+--   err_table = { status, message } (or a kong.response.exit return value
+--   from custom_validate_token_signature)
+-------------------------------------------------------------------------------
+local function verify_zitadel_token(conf, token)
+    local jwt, err = jwt_decoder:new(token)
+    if err then
+        kong.log.warn("Malformed JWT received from " .. (kong.client.get_forwarded_ip() or "unknown") .. ": " .. tostring(err) .. " " .. token_fingerprint(token))
+        inc_warn(conf, "malformed_jwt")
+        return nil, {
+            status = 401,
+            message = "Unauthorized"
+        }
+    end
+
+    local claims = jwt.claims
+
+    kong.log.debug("JWT issuer: " .. tostring(claims.iss) .. ", subject: " .. tostring(claims.sub))
+
+    local matched_iss = validate_issuer(conf.allowed_iss, jwt.claims)
+    if not matched_iss then
+        kong.log.warn("Rejected token with disallowed issuer: " .. tostring(claims.iss) .. " from " .. (kong.client.get_forwarded_ip() or "unknown"))
+        inc_warn(conf, "disallowed_issuer")
+        return nil, {
+            status = 401,
+            message = "Unauthorized"
+        }
+    end
+
+    local algorithm = conf.algorithm
+
+    if jwt.header.alg ~= algorithm then
+        kong.log.warn("Rejected token with unexpected algorithm: " .. tostring(jwt.header.alg) .. " (expected " .. algorithm .. ") from " .. (kong.client.get_forwarded_ip() or "unknown"))
+        inc_warn(conf, "unexpected_algorithm")
+        return nil, {
+            status = 403,
+            message = "Forbidden"
+        }
+    end
+
+    err = custom_validate_token_signature(conf, jwt, matched_iss)
+    if err ~= nil then
+        return nil, err
+    end
+
+    local ok_claims, errors = jwt:verify_registered_claims(conf.claims_to_verify)
+    if not ok_claims then
+        kong.log.warn("Token claims validation failed from " .. (kong.client.get_forwarded_ip() or "unknown") .. ": " .. custom_helper_table_to_string(errors))
+        local reason = "claims_validation_failed"
+        if type(errors) == "table" and errors.exp and tostring(errors.exp):find("expired") then
+            reason = "token_expired"
+        end
+        inc_warn(conf, reason)
+        return nil, {
+            status = 401,
+            message = "Unauthorized"
+        }
+    end
+
+    if conf.maximum_expiration ~= nil and conf.maximum_expiration > 0 then
+        local ok, max_errors = jwt:check_maximum_expiration(conf.maximum_expiration)
+        if not ok then
+            kong.log.warn("Token maximum expiration check failed from " .. (kong.client.get_forwarded_ip() or "unknown") .. ": " .. custom_helper_table_to_string(max_errors))
+            inc_warn(conf, "max_expiration_exceeded")
+            return nil, {
+                status = 403,
+                message = "Forbidden"
+            }
+        end
+    end
+
+    return jwt
+end
+
 local function do_authentication(conf)
     local token, err = retrieve_tokens(conf)
     if err then
@@ -449,84 +529,16 @@ local function do_authentication(conf)
         end
     end
 
-    -- Decode token to find out who the consumer is
-    local jwt, err = jwt_decoder:new(token)
-    if err then
-        kong.log.warn("Malformed JWT received from " .. (kong.client.get_forwarded_ip() or "unknown") .. ": " .. tostring(err) .. " " .. token_fingerprint(token))
-        inc_warn(conf, "malformed_jwt")
-        return false, {
-            status = 401,
-            message = "Unauthorized"
-        }
-    end
-
-    local claims = jwt.claims
-    local header = jwt.header
-
-    kong.log.debug("JWT issuer: " .. tostring(claims.iss) .. ", subject: " .. tostring(claims.sub))
-
-    -- Verify that the issuer is allowed
-    local matched_iss = validate_issuer(conf.allowed_iss, jwt.claims)
-    if not matched_iss then
-        kong.log.warn("Rejected token with disallowed issuer: " .. tostring(claims.iss) .. " from " .. (kong.client.get_forwarded_ip() or "unknown"))
-        inc_warn(conf, "disallowed_issuer")
-        return false, {
-            status = 401,
-            message = "Unauthorized"
-        }
-    end
-
-    local algorithm = conf.algorithm
-
-    -- Verify "alg"
-    if jwt.header.alg ~= algorithm then
-        kong.log.warn("Rejected token with unexpected algorithm: " .. tostring(jwt.header.alg) .. " (expected " .. algorithm .. ") from " .. (kong.client.get_forwarded_ip() or "unknown"))
-        inc_warn(conf, "unexpected_algorithm")
-        return false, {
-            status = 403,
-            message = "Forbidden"
-        }
-    end
-
-    -- Now verify the JWT signature
-    err = custom_validate_token_signature(conf, jwt, matched_iss)
-    if err ~= nil then
-        return false, err
-    end
-
-    -- Verify the JWT registered claims
-    local ok_claims, errors = jwt:verify_registered_claims(conf.claims_to_verify)
-    if not ok_claims then
-        kong.log.warn("Token claims validation failed from " .. (kong.client.get_forwarded_ip() or "unknown") .. ": " .. custom_helper_table_to_string(errors))
-        local reason = "claims_validation_failed"
-        if type(errors) == "table" and errors.exp and tostring(errors.exp):find("expired") then
-            reason = "token_expired"
-        end
-        inc_warn(conf, reason)
-        return false, {
-            status = 401,
-            message = "Unauthorized"
-        }
-    end
-
-    -- Verify the JWT registered claims
-    if conf.maximum_expiration ~= nil and conf.maximum_expiration > 0 then
-        local ok, errors = jwt:check_maximum_expiration(conf.maximum_expiration)
-        if not ok then
-            kong.log.warn("Token maximum expiration check failed from " .. (kong.client.get_forwarded_ip() or "unknown") .. ": " .. custom_helper_table_to_string(errors))
-            inc_warn(conf, "max_expiration_exceeded")
-            return false, {
-                status = 403,
-                message = "Forbidden"
-            }
-        end
+    local jwt, verr = verify_zitadel_token(conf, token)
+    if not jwt then
+        return false, verr
     end
 
     -- Match consumer
     if conf.consumer_match then
-        local ok, err = custom_match_consumer(conf, jwt)
+        local ok, merr = custom_match_consumer(conf, jwt)
         if not ok then
-            return ok, err
+            return ok, merr
         end
     end
 
@@ -534,6 +546,140 @@ local function do_authentication(conf)
 
     kong.ctx.shared.unique_jwt_token = token
     return true
+end
+
+-------------------------------------------------------------------------------
+-- Mint a single-use opaque WebSocket ticket.
+-- Answers the request directly — never proxied upstream.
+-------------------------------------------------------------------------------
+local function mint_ws_ticket(conf)
+    if not conf.redis_host or conf.redis_host == "" then
+        kong.log.err("ws_ticket_enabled but redis_host is not configured")
+        inc_warn(conf, "ws_ticket_redis_error")
+        return kong.response.exit(503, {
+            message = "Service Unavailable"
+        })
+    end
+    if not conf.ticket_scope or conf.ticket_scope == "" then
+        kong.log.err("ws_ticket_enabled but ticket_scope is not configured")
+        return kong.response.exit(500, {
+            message = "An unexpected error occurred"
+        })
+    end
+
+    local token = ws_ticket.bearer_from_authorization()
+    if not token then
+        kong.log.warn("Ticket mint rejected: missing Authorization Bearer from " .. (kong.client.get_forwarded_ip() or "unknown"))
+        return kong.response.exit(401, {
+            message = "Unauthorized"
+        })
+    end
+
+    local jwt, verr = verify_zitadel_token(conf, token)
+    if not jwt then
+        if type(verr) == "table" and verr.status then
+            return kong.response.exit(verr.status, {
+                message = verr.message or "Unauthorized"
+            })
+        end
+        -- custom_validate_token_signature already exited
+        return verr
+    end
+
+    local ticket, result = ws_ticket.mint(conf, jwt.claims)
+    if not ticket then
+        local err = result
+        if err.reason then
+            if err.reason == "ws_ticket_mint_missing_claims" then
+                kong.log.warn("Ticket mint rejected: missing claim " .. tostring(err.claim) .. " from " .. (kong.client.get_forwarded_ip() or "unknown"))
+            elseif err.reason == "ws_ticket_mint_rate_limited" then
+                kong.log.warn("Ticket mint rate-limited for subject from " .. (kong.client.get_forwarded_ip() or "unknown"))
+                inc_warn(conf, err.reason)
+            elseif err.reason == "ws_ticket_redis_error" then
+                kong.log.err("Ticket mint Redis error: ", err.redis_error)
+                inc_warn(conf, err.reason)
+            else
+                kong.log.err("Ticket mint failed: ", err.reason, " ", err.redis_error)
+            end
+        end
+        return kong.response.exit(err.status or 500, {
+            message = err.message or "An unexpected error occurred"
+        })
+    end
+
+    return kong.response.exit(200, {
+        ticket = ticket,
+        expires_in = result
+    }, {
+        ["Cache-Control"] = "no-store",
+        ["Content-Type"] = "application/json"
+    })
+end
+
+-------------------------------------------------------------------------------
+-- Consume a single-use opaque ticket from ?ticket= on a WebSocket upgrade.
+-- Exclusive path: no fallback to the token path on failure.
+-------------------------------------------------------------------------------
+local function consume_ws_ticket(conf, ticket)
+    if not conf.redis_host or conf.redis_host == "" then
+        kong.log.err("ws_ticket_enabled but redis_host is not configured")
+        inc_warn(conf, "ws_ticket_redis_error")
+        return kong.response.exit(503, {
+            message = "Service Unavailable"
+        })
+    end
+
+    if not ws_ticket.is_websocket_upgrade() then
+        kong.log.warn("Ticket presented on non-upgrade request from " .. (kong.client.get_forwarded_ip() or "unknown"))
+        inc_warn(conf, "ws_ticket_unknown")
+        return kong.response.exit(401, {
+            message = "Unauthorized"
+        })
+    end
+
+    local origin_ok, origin_why = ws_ticket.origin_allowed(conf)
+    if not origin_ok then
+        kong.log.warn("Ticket Origin rejected (" .. tostring(origin_why) .. ") from " .. (kong.client.get_forwarded_ip() or "unknown"))
+        inc_warn(conf, "ws_ticket_origin_rejected")
+        return kong.response.exit(401, {
+            message = "Unauthorized"
+        })
+    end
+
+    local record, err = ws_ticket.consume(conf, ticket)
+    if not record then
+        local limited, lreason = ws_ticket.fail_rate_limited(conf)
+        if limited then
+            if lreason == "ws_ticket_redis_error" then
+                inc_warn(conf, "ws_ticket_redis_error")
+                return kong.response.exit(503, {
+                    message = "Service Unavailable"
+                })
+            end
+            kong.log.warn("Ticket fail-rate limited from " .. (kong.client.get_forwarded_ip() or "unknown"))
+            return kong.response.exit(429, {
+                message = "Too Many Requests"
+            })
+        end
+
+        if err.reason == "ws_ticket_redis_error" then
+            kong.log.err("Ticket consume Redis error: ", err.redis_error)
+            inc_warn(conf, "ws_ticket_redis_error")
+        elseif err.reason == "ws_ticket_scope_mismatch" then
+            kong.log.warn("Ticket scope mismatch from " .. (kong.client.get_forwarded_ip() or "unknown"))
+            inc_warn(conf, "ws_ticket_scope_mismatch")
+        else
+            kong.log.warn("Ticket unknown/expired/replayed from " .. (kong.client.get_forwarded_ip() or "unknown"))
+            inc_warn(conf, "ws_ticket_unknown")
+        end
+        return kong.response.exit(err.status or 401, {
+            message = err.message or "Unauthorized"
+        })
+    end
+
+    ws_ticket.set_identity_headers(record)
+    ws_ticket.strip_ticket_from_query(conf)
+    -- Authenticated via ticket; continue to proxy the upgrade.
 end
 
 local function set_anonymous_consumer(anonymous)
@@ -581,6 +727,21 @@ function UniqueJwtAuthHandler:access(conf)
     -- check if preflight request and whether it should be authenticated
     if not conf.run_on_preflight and kong.request.get_method() == "OPTIONS" then
         return
+    end
+
+    -- Single-use opaque WebSocket tickets. Default-off; when disabled the
+    -- existing ?token= / cookie / Authorization flow is unchanged.
+    if conf.ws_ticket_enabled then
+        local mint_path = conf.ticket_mint_path or "/auth/ticket"
+        if kong.request.get_method() == "POST" and kong.request.get_path() == mint_path then
+            return mint_ws_ticket(conf)
+        end
+
+        local ticket = ws_ticket.ticket_from_query(conf)
+        if ticket then
+            -- Exclusive: ?ticket= never falls through to the token path.
+            return consume_ws_ticket(conf, ticket)
+        end
     end
 
     if conf.anonymous then

--- a/charts/kong-plugins/files/unique-jwt-auth/redis_store.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/redis_store.lua
@@ -36,7 +36,7 @@ return c
 ]]
 
 local function pool_name(conf)
-  local db = conf.redis_database or 0
+  local db = conf.redis_database or 7
   return conf.redis_host .. ":" .. tostring(conf.redis_port) .. ":" .. tostring(db)
 end
 
@@ -70,7 +70,7 @@ local function connect(conf)
       end
     end
 
-    local db = conf.redis_database or 0
+    local db = conf.redis_database or 7
     if db ~= 0 then
       local res, serr = red:select(db)
       if not res then

--- a/charts/kong-plugins/files/unique-jwt-auth/redis_store.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/redis_store.lua
@@ -7,12 +7,32 @@ local redis = require "resty.redis"
 
 local _M = {}
 
+-- Scope is checked inside the script so a ticket presented with the wrong
+-- scope is rejected WITHOUT being deleted: a misrouted client must not burn
+-- a ticket that is still valid for its intended socket. The sentinel cannot
+-- collide with a stored record because records are always JSON objects.
 local CONSUME_SCRIPT = [[
 local v = redis.call('GET', KEYS[1])
-if v then
-  redis.call('DEL', KEYS[1])
+if not v then
+  return nil
 end
+local ok, rec = pcall(cjson.decode, v)
+if ok and type(rec) == 'table' and rec.scope ~= ARGV[1] then
+  return 'SCOPE_MISMATCH'
+end
+redis.call('DEL', KEYS[1])
 return v
+]]
+
+-- INCR and EXPIRE must be one atomic unit: a failure between the two would
+-- leave a counter without a TTL that never resets, permanently rate-limiting
+-- that subject/IP until the key is deleted by hand.
+local INCR_SCRIPT = [[
+local c = redis.call('INCR', KEYS[1])
+if c == 1 then
+  redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return c
 ]]
 
 local function pool_name(conf)
@@ -97,15 +117,16 @@ function _M.put(conf, key, value, ttl)
   return true
 end
 
---- Atomically retrieve and delete a ticket record (EVAL GET+DEL).
--- @return record string, or nil + err (nil/"not found" when missing)
-function _M.consume(conf, key)
+--- Atomically retrieve and delete a ticket record (EVAL GET+scope check+DEL).
+-- A wrong-scope attempt leaves the record in place.
+-- @return record string, or nil + err ("not found" / "scope mismatch" / redis error)
+function _M.consume(conf, key, scope)
   local red, err = connect(conf)
   if not red then
     return nil, err
   end
 
-  local res, serr = red:eval(CONSUME_SCRIPT, 1, prefixed(conf, key))
+  local res, serr = red:eval(CONSUME_SCRIPT, 1, prefixed(conf, key), scope or "")
   keepalive(red)
 
   if serr then
@@ -114,31 +135,26 @@ function _M.consume(conf, key)
   if res == ngx.null or res == nil then
     return nil, "not found"
   end
+  if res == "SCOPE_MISMATCH" then
+    return nil, "scope mismatch"
+  end
   return res
 end
 
 --- Increment a counter with a sliding window TTL. Returns the new count.
+-- Atomic EVAL so the counter can never exist without a TTL.
 function _M.incr_with_expiry(conf, key, window)
   local red, err = connect(conf)
   if not red then
     return nil, err
   end
 
-  local full = prefixed(conf, key)
-  local count, ierr = red:incr(full)
-  if not count then
-    keepalive(red)
+  local count, ierr = red:eval(INCR_SCRIPT, 1, prefixed(conf, key), window)
+  keepalive(red)
+
+  if not count or count == ngx.null then
     return nil, "redis INCR failed: " .. tostring(ierr)
   end
-
-  if count == 1 then
-    local _, eerr = red:expire(full, window)
-    if eerr then
-      kong.log.warn("redis EXPIRE failed: ", eerr)
-    end
-  end
-
-  keepalive(red)
   return count
 end
 

--- a/charts/kong-plugins/files/unique-jwt-auth/redis_store.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/redis_store.lua
@@ -1,0 +1,145 @@
+-- Shared Redis helpers for single-use WebSocket tickets.
+-- Connection pattern follows Kong's rate-limiting plugin: resty.redis per
+-- request, AUTH/SELECT only on a fresh socket, keepalive pool keyed by
+-- host:port:database so SELECT'd connections are never mixed.
+
+local redis = require "resty.redis"
+
+local _M = {}
+
+local CONSUME_SCRIPT = [[
+local v = redis.call('GET', KEYS[1])
+if v then
+  redis.call('DEL', KEYS[1])
+end
+return v
+]]
+
+local function pool_name(conf)
+  local db = conf.redis_database or 0
+  return conf.redis_host .. ":" .. tostring(conf.redis_port) .. ":" .. tostring(db)
+end
+
+local function connect(conf)
+  local red = redis:new()
+  red:set_timeout(conf.redis_timeout_ms or 2000)
+
+  local ok, err
+  if conf.redis_ssl then
+    ok, err = red:connect(conf.redis_host, conf.redis_port, {
+      ssl = true,
+      ssl_verify = conf.redis_ssl_verify and true or false,
+      pool = pool_name(conf),
+    })
+  else
+    ok, err = red:connect(conf.redis_host, conf.redis_port, {
+      pool = pool_name(conf),
+    })
+  end
+  if not ok then
+    return nil, "redis connect failed: " .. tostring(err)
+  end
+
+  local reused = red:get_reused_times()
+  if reused == 0 then
+    if conf.redis_password and conf.redis_password ~= "" then
+      local res, aerr = red:auth(conf.redis_password)
+      if not res then
+        red:close()
+        return nil, "redis auth failed: " .. tostring(aerr)
+      end
+    end
+
+    local db = conf.redis_database or 0
+    if db ~= 0 then
+      local res, serr = red:select(db)
+      if not res then
+        red:close()
+        return nil, "redis select failed: " .. tostring(serr)
+      end
+    end
+  end
+
+  return red
+end
+
+local function keepalive(red)
+  -- 10k idle pool, 60s idle timeout — same ballpark as Kong's own plugins
+  local ok, err = red:set_keepalive(60000, 100)
+  if not ok then
+    kong.log.warn("redis set_keepalive failed: ", err)
+    red:close()
+  end
+end
+
+local function prefixed(conf, key)
+  local prefix = conf.redis_key_prefix or "ws_ticket:"
+  return prefix .. key
+end
+
+--- Store a ticket record. Fails if the key already exists (SET NX).
+-- @return true on success, nil + err otherwise
+function _M.put(conf, key, value, ttl)
+  local red, err = connect(conf)
+  if not red then
+    return nil, err
+  end
+
+  local res, serr = red:set(prefixed(conf, key), value, "EX", ttl, "NX")
+  keepalive(red)
+
+  if serr then
+    return nil, "redis SET failed: " .. tostring(serr)
+  end
+  if res ~= "OK" then
+    return nil, "redis SET NX conflict"
+  end
+  return true
+end
+
+--- Atomically retrieve and delete a ticket record (EVAL GET+DEL).
+-- @return record string, or nil + err (nil/"not found" when missing)
+function _M.consume(conf, key)
+  local red, err = connect(conf)
+  if not red then
+    return nil, err
+  end
+
+  local res, serr = red:eval(CONSUME_SCRIPT, 1, prefixed(conf, key))
+  keepalive(red)
+
+  if serr then
+    return nil, "redis EVAL failed: " .. tostring(serr)
+  end
+  if res == ngx.null or res == nil then
+    return nil, "not found"
+  end
+  return res
+end
+
+--- Increment a counter with a sliding window TTL. Returns the new count.
+function _M.incr_with_expiry(conf, key, window)
+  local red, err = connect(conf)
+  if not red then
+    return nil, err
+  end
+
+  local full = prefixed(conf, key)
+  local count, ierr = red:incr(full)
+  if not count then
+    keepalive(red)
+    return nil, "redis INCR failed: " .. tostring(ierr)
+  end
+
+  if count == 1 then
+    local _, eerr = red:expire(full, window)
+    if eerr then
+      kong.log.warn("redis EXPIRE failed: ", eerr)
+    end
+  end
+
+  keepalive(red)
+  return count
+end
+
+return _M

--- a/charts/kong-plugins/files/unique-jwt-auth/schema.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/schema.lua
@@ -149,6 +149,103 @@ local schema = {
                     type = "string",
                     default = "unique_jwt_auth_security_warnings_total"
                 }
+            }, {
+                -- Single-use opaque WebSocket tickets (Redis-backed).
+                -- Default false: existing ?token= / cookie / Authorization flow unchanged.
+                ws_ticket_enabled = {
+                    type = "boolean",
+                    default = false,
+                    required = true
+                }
+            }, {
+                ticket_param_name = {
+                    type = "string",
+                    default = "ticket"
+                }
+            }, {
+                ticket_mint_path = {
+                    type = "string",
+                    default = "/auth/ticket"
+                }
+            }, {
+                ticket_ttl = {
+                    type = "number",
+                    default = 20,
+                    between = {5, 60}
+                }
+            }, {
+                -- Route/service binding written into the ticket record and
+                -- checked on consume so a chat ticket cannot open another socket.
+                ticket_scope = {
+                    type = "string"
+                }
+            }, {
+                ticket_allowed_origins = {
+                    type = "set",
+                    elements = {
+                        type = "string"
+                    },
+                    default = {}
+                }
+            }, {
+                -- Max mint requests per authenticated subject per 60s window.
+                -- 0 disables the limit.
+                ticket_mint_rate_limit = {
+                    type = "number",
+                    default = 60,
+                    between = {0, 10000}
+                }
+            }, {
+                -- Max failed consumptions per client IP per 60s window.
+                -- 0 disables the limit.
+                ticket_fail_rate_limit = {
+                    type = "number",
+                    default = 30,
+                    between = {0, 10000}
+                }
+            }, {
+                redis_host = {
+                    type = "string"
+                }
+            }, {
+                redis_port = {
+                    type = "number",
+                    default = 6379,
+                    between = {1, 65535}
+                }
+            }, {
+                redis_ssl = {
+                    type = "boolean",
+                    default = false
+                }
+            }, {
+                redis_ssl_verify = {
+                    type = "boolean",
+                    default = true
+                }
+            }, {
+                redis_password = {
+                    type = "string",
+                    referenceable = true,
+                    encrypted = true
+                }
+            }, {
+                redis_timeout_ms = {
+                    type = "number",
+                    default = 2000,
+                    between = {50, 60000}
+                }
+            }, {
+                redis_database = {
+                    type = "number",
+                    default = 0,
+                    between = {0, 15}
+                }
+            }, {
+                redis_key_prefix = {
+                    type = "string",
+                    default = "ws_ticket:"
+                }
             }}
         }
     }}

--- a/charts/kong-plugins/files/unique-jwt-auth/schema.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/schema.lua
@@ -238,7 +238,7 @@ local schema = {
             }, {
                 redis_database = {
                     type = "number",
-                    default = 0,
+                    default = 7,
                     between = {0, 15}
                 }
             }, {

--- a/charts/kong-plugins/files/unique-jwt-auth/ws_ticket.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/ws_ticket.lua
@@ -238,13 +238,23 @@ function _M.consume(conf, ticket)
   end
 
   local hash = sha256_hex(ticket)
-  local raw, err = redis_store.consume(conf, ticket_key(hash))
+  -- Scope is enforced inside the atomic consume script: a wrong-scope attempt
+  -- is rejected without deleting the record, so a misrouted client does not
+  -- burn a ticket that is still valid for its intended socket.
+  local raw, err = redis_store.consume(conf, ticket_key(hash), conf.ticket_scope or "")
   if not raw then
     if err == "not found" then
       return nil, {
         status = 401,
         message = "Unauthorized",
         reason = "ws_ticket_unknown",
+      }
+    end
+    if err == "scope mismatch" then
+      return nil, {
+        status = 401,
+        message = "Unauthorized",
+        reason = "ws_ticket_scope_mismatch",
       }
     end
     return nil, {
@@ -262,14 +272,6 @@ function _M.consume(conf, ticket)
       message = "Unauthorized",
       reason = "ws_ticket_unknown",
       redis_error = derr,
-    }
-  end
-
-  if record.scope ~= conf.ticket_scope then
-    return nil, {
-      status = 401,
-      message = "Unauthorized",
-      reason = "ws_ticket_scope_mismatch",
     }
   end
 

--- a/charts/kong-plugins/files/unique-jwt-auth/ws_ticket.lua
+++ b/charts/kong-plugins/files/unique-jwt-auth/ws_ticket.lua
@@ -1,0 +1,324 @@
+-- Mint and consume single-use opaque WebSocket upgrade tickets.
+-- Tickets are random opaque values (not JWTs). Only the SHA-256 hash is
+-- stored in Redis together with identity, scope, and issuance time.
+
+local cjson = require "cjson.safe"
+local resty_sha256 = require "resty.sha256"
+local to_hex = require "resty.string".to_hex
+local openssl_rand = require "resty.openssl.rand"
+local redis_store = require "kong.plugins.unique-jwt-auth.redis_store"
+
+local encode_base64 = ngx.encode_base64
+
+local _M = {}
+
+local TICKET_BYTES = 32 -- 256 bits
+local RATE_WINDOW_S = 60
+
+local function b64url(raw)
+  local b64 = encode_base64(raw, true) -- no_padding
+  return (b64:gsub("+", "-"):gsub("/", "_"))
+end
+
+local function sha256_hex(value)
+  local sha = resty_sha256:new()
+  sha:update(value)
+  return to_hex(sha:final())
+end
+
+local function ticket_key(hash)
+  return "t:" .. hash
+end
+
+local function mint_rate_key(sub)
+  return "mint:" .. sub
+end
+
+local function fail_rate_key(ip)
+  return "fail:" .. (ip or "unknown")
+end
+
+--- Extract a Bearer token from Authorization (header only — never query/cookie).
+function _M.bearer_from_authorization()
+  local header = kong.request.get_header("authorization")
+  if not header or header == "" then
+    return nil
+  end
+  if type(header) == "table" then
+    header = header[1]
+  end
+  local m = ngx.re.match(header, [[^\s*[Bb]earer\s+(.+)$]], "jo")
+  if not m or not m[1] or m[1] == "" then
+    return nil
+  end
+  return m[1]
+end
+
+--- True when the request is a genuine WebSocket upgrade.
+function _M.is_websocket_upgrade()
+  local upgrade = kong.request.get_header("upgrade")
+  if not upgrade then
+    return false
+  end
+  if type(upgrade) == "table" then
+    upgrade = upgrade[1]
+  end
+  if not ngx.re.find(upgrade, [[websocket]], "ijo") then
+    return false
+  end
+
+  local connection = kong.request.get_header("connection")
+  if not connection then
+    return false
+  end
+  if type(connection) == "table" then
+    connection = connection[1]
+  end
+  return ngx.re.find(connection, [[upgrade]], "ijo") and true or false
+end
+
+--- Exact-match Origin against the configured allowlist.
+-- When the allowlist is empty/nil, Origin is not enforced.
+-- @return true, or false + reason
+function _M.origin_allowed(conf)
+  local allowed = conf.ticket_allowed_origins
+  if not allowed or #allowed == 0 then
+    return true
+  end
+
+  local origin = kong.request.get_header("origin")
+  if not origin or origin == "" then
+    return false, "missing"
+  end
+  if type(origin) == "table" then
+    origin = origin[1]
+  end
+
+  for _, entry in ipairs(allowed) do
+    if origin == entry then
+      return true
+    end
+  end
+  return false, "mismatch"
+end
+
+--- Read the ticket query parameter (never logged by callers).
+function _M.ticket_from_query(conf)
+  local name = conf.ticket_param_name or "ticket"
+  local args = kong.request.get_query()
+  local value = args[name]
+  if not value or value == "" then
+    return nil
+  end
+  if type(value) == "table" then
+    value = value[1]
+  end
+  if not value or value == "" then
+    return nil
+  end
+  return value
+end
+
+--- Strip the ticket query parameter before proxying upstream.
+function _M.strip_ticket_from_query(conf)
+  local name = conf.ticket_param_name or "ticket"
+  local args = kong.request.get_query()
+  if args[name] == nil then
+    return
+  end
+  args[name] = nil
+  kong.service.request.set_query(args)
+end
+
+local function missing_identity(claims)
+  if not claims.sub or claims.sub == "" then
+    return "sub"
+  end
+  local cid = claims["urn:zitadel:iam:user:resourceowner:id"]
+  if not cid or cid == "" then
+    return "urn:zitadel:iam:user:resourceowner:id"
+  end
+  return nil
+end
+
+--- Mint a single-use ticket for the verified JWT claims.
+-- @return ticket, expires_in on success; nil, err_table on failure
+--   err_table = { status, message, reason?, redis_error? }
+function _M.mint(conf, claims)
+  local missing = missing_identity(claims)
+  if missing then
+    return nil, {
+      status = 401,
+      message = "Unauthorized",
+      reason = "ws_ticket_mint_missing_claims",
+      claim = missing,
+    }
+  end
+
+  local sub = claims.sub
+  local company_id = claims["urn:zitadel:iam:user:resourceowner:id"]
+  local ttl = conf.ticket_ttl or 20
+  local scope = conf.ticket_scope
+  if not scope or scope == "" then
+    return nil, {
+      status = 500,
+      message = "An unexpected error occurred",
+      reason = "ws_ticket_misconfigured",
+    }
+  end
+
+  local limit = conf.ticket_mint_rate_limit
+  if limit and limit > 0 then
+    local count, rerr = redis_store.incr_with_expiry(conf, mint_rate_key(sub), RATE_WINDOW_S)
+    if not count then
+      return nil, {
+        status = 503,
+        message = "Service Unavailable",
+        reason = "ws_ticket_redis_error",
+        redis_error = rerr,
+      }
+    end
+    if count > limit then
+      return nil, {
+        status = 429,
+        message = "Too Many Requests",
+        reason = "ws_ticket_mint_rate_limited",
+      }
+    end
+  end
+
+  local raw, rerr = openssl_rand.bytes(TICKET_BYTES)
+  if not raw then
+    return nil, {
+      status = 500,
+      message = "An unexpected error occurred",
+      reason = "ws_ticket_rng_failed",
+      redis_error = rerr,
+    }
+  end
+
+  local ticket = b64url(raw)
+  local hash = sha256_hex(ticket)
+  local record = cjson.encode({
+    sub = sub,
+    company_id = company_id,
+    scope = scope,
+    iat = ngx.time(),
+  })
+  if not record then
+    return nil, {
+      status = 500,
+      message = "An unexpected error occurred",
+      reason = "ws_ticket_encode_failed",
+    }
+  end
+
+  local ok, serr = redis_store.put(conf, ticket_key(hash), record, ttl)
+  if not ok then
+    return nil, {
+      status = 503,
+      message = "Service Unavailable",
+      reason = "ws_ticket_redis_error",
+      redis_error = serr,
+    }
+  end
+
+  return ticket, ttl
+end
+
+--- Consume a ticket: atomic retrieve-and-delete, validate scope.
+-- @return record table on success; nil, err_table on failure
+function _M.consume(conf, ticket)
+  if not ticket or ticket == "" then
+    return nil, {
+      status = 401,
+      message = "Unauthorized",
+      reason = "ws_ticket_unknown",
+    }
+  end
+
+  local hash = sha256_hex(ticket)
+  local raw, err = redis_store.consume(conf, ticket_key(hash))
+  if not raw then
+    if err == "not found" then
+      return nil, {
+        status = 401,
+        message = "Unauthorized",
+        reason = "ws_ticket_unknown",
+      }
+    end
+    return nil, {
+      status = 503,
+      message = "Service Unavailable",
+      reason = "ws_ticket_redis_error",
+      redis_error = err,
+    }
+  end
+
+  local record, derr = cjson.decode(raw)
+  if not record or type(record) ~= "table" then
+    return nil, {
+      status = 401,
+      message = "Unauthorized",
+      reason = "ws_ticket_unknown",
+      redis_error = derr,
+    }
+  end
+
+  if record.scope ~= conf.ticket_scope then
+    return nil, {
+      status = 401,
+      message = "Unauthorized",
+      reason = "ws_ticket_scope_mismatch",
+    }
+  end
+
+  if not record.sub or record.sub == "" or not record.company_id or record.company_id == "" then
+    return nil, {
+      status = 401,
+      message = "Unauthorized",
+      reason = "ws_ticket_unknown",
+    }
+  end
+
+  return record
+end
+
+--- Rate-limit failed consumptions per client IP. Returns true if limited.
+function _M.fail_rate_limited(conf)
+  local limit = conf.ticket_fail_rate_limit
+  if not limit or limit <= 0 then
+    return false
+  end
+
+  local ip = kong.client.get_forwarded_ip() or "unknown"
+  local count, err = redis_store.incr_with_expiry(conf, fail_rate_key(ip), RATE_WINDOW_S)
+  if not count then
+    -- fail closed on Redis errors during rate limiting too
+    kong.log.err("ticket fail-rate Redis error: ", err)
+    return true, "ws_ticket_redis_error"
+  end
+  if count > limit then
+    return true, "ws_ticket_fail_rate_limited"
+  end
+  return false
+end
+
+--- Stamp identity headers a ticket can vouch for; clear the rest.
+function _M.set_identity_headers(record)
+  local set_header = kong.service.request.set_header
+  local clear_header = kong.service.request.clear_header
+
+  set_header("x-user-id", record.sub)
+  set_header("x-company-id", record.company_id)
+  clear_header("x-user-roles")
+  clear_header("x-company-name")
+  clear_header("x-company-domain")
+end
+
+-- Exported for tests
+_M._sha256_hex = sha256_hex
+_M._ticket_key = ticket_key
+_M._missing_identity = missing_identity
+
+return _M

--- a/charts/kong-plugins/templates/alerts/alerts-security-warnings.yaml
+++ b/charts/kong-plugins/templates/alerts/alerts-security-warnings.yaml
@@ -189,6 +189,91 @@ spec:
             Tokens were rejected because their lifetime exceeds the configured maximum_expiration. This may indicate clients issuing overly long-lived tokens.
             Loki: `{app="gateway"} |= "maximum expiration"`
 {{- end }}
+{{- if dig "KongJwtAuthWsTicketUnknown" "enabled" true $rules }}
+      - alert: KongJwtAuthWsTicketUnknown
+        expr: |
+          sum(increase({{ $jwtMetric }}{reason="ws_ticket_unknown"}[{{ dig "KongJwtAuthWsTicketUnknown" "interval" "5m" $rules }}])) > {{ dig "KongJwtAuthWsTicketUnknown" "threshold" 5 $rules }}
+        for: {{ dig "KongJwtAuthWsTicketUnknown" "for" "0m" $rules }}
+        labels:
+          severity: {{ dig "KongJwtAuthWsTicketUnknown" "severity" "warning" $rules }}
+          alertGroup: security-warnings
+          {{- with .Values.prometheus.defaultAlerts.securityWarnings.additionalLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        annotations:
+          summary: "Kong JWT auth rejected unknown, expired, or replayed WebSocket tickets"
+          description: |
+            Single-use WebSocket tickets were rejected because they were missing from Redis (forged, expired, or already consumed) or presented outside an upgrade.
+            Loki: `{app="gateway"} |= "Ticket unknown"`
+{{- end }}
+{{- if dig "KongJwtAuthWsTicketScopeMismatch" "enabled" true $rules }}
+      - alert: KongJwtAuthWsTicketScopeMismatch
+        expr: |
+          sum(increase({{ $jwtMetric }}{reason="ws_ticket_scope_mismatch"}[{{ dig "KongJwtAuthWsTicketScopeMismatch" "interval" "5m" $rules }}])) > {{ dig "KongJwtAuthWsTicketScopeMismatch" "threshold" 2 $rules }}
+        for: {{ dig "KongJwtAuthWsTicketScopeMismatch" "for" "0m" $rules }}
+        labels:
+          severity: {{ dig "KongJwtAuthWsTicketScopeMismatch" "severity" "critical" $rules }}
+          alertGroup: security-warnings
+          {{- with .Values.prometheus.defaultAlerts.securityWarnings.additionalLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        annotations:
+          summary: "Kong JWT auth rejected WebSocket tickets with mismatched scope"
+          description: |
+            A ticket minted for one WebSocket route/service was presented on another. This should not occur with well-behaved clients.
+            Loki: `{app="gateway"} |= "Ticket scope mismatch"`
+{{- end }}
+{{- if dig "KongJwtAuthWsTicketOriginRejected" "enabled" true $rules }}
+      - alert: KongJwtAuthWsTicketOriginRejected
+        expr: |
+          sum(increase({{ $jwtMetric }}{reason="ws_ticket_origin_rejected"}[{{ dig "KongJwtAuthWsTicketOriginRejected" "interval" "5m" $rules }}])) > {{ dig "KongJwtAuthWsTicketOriginRejected" "threshold" 2 $rules }}
+        for: {{ dig "KongJwtAuthWsTicketOriginRejected" "for" "0m" $rules }}
+        labels:
+          severity: {{ dig "KongJwtAuthWsTicketOriginRejected" "severity" "warning" $rules }}
+          alertGroup: security-warnings
+          {{- with .Values.prometheus.defaultAlerts.securityWarnings.additionalLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        annotations:
+          summary: "Kong JWT auth rejected WebSocket tickets with disallowed Origin"
+          description: |
+            Upgrade requests carrying a ticket were rejected because the Origin header was missing or not on the exact allowlist.
+            Loki: `{app="gateway"} |= "Ticket Origin rejected"`
+{{- end }}
+{{- if dig "KongJwtAuthWsTicketMintRateLimited" "enabled" true $rules }}
+      - alert: KongJwtAuthWsTicketMintRateLimited
+        expr: |
+          sum(increase({{ $jwtMetric }}{reason="ws_ticket_mint_rate_limited"}[{{ dig "KongJwtAuthWsTicketMintRateLimited" "interval" "5m" $rules }}])) > {{ dig "KongJwtAuthWsTicketMintRateLimited" "threshold" 10 $rules }}
+        for: {{ dig "KongJwtAuthWsTicketMintRateLimited" "for" "0m" $rules }}
+        labels:
+          severity: {{ dig "KongJwtAuthWsTicketMintRateLimited" "severity" "warning" $rules }}
+          alertGroup: security-warnings
+          {{- with .Values.prometheus.defaultAlerts.securityWarnings.additionalLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        annotations:
+          summary: "Kong JWT auth rate-limited WebSocket ticket minting"
+          description: |
+            Authenticated subjects exceeded ticket_mint_rate_limit. A sustained burst may indicate mint abuse.
+            Loki: `{app="gateway"} |= "Ticket mint rate-limited"`
+{{- end }}
+{{- if dig "KongJwtAuthWsTicketRedisError" "enabled" true $rules }}
+      - alert: KongJwtAuthWsTicketRedisError
+        expr: |
+          sum(increase({{ $jwtMetric }}{reason="ws_ticket_redis_error"}[{{ dig "KongJwtAuthWsTicketRedisError" "interval" "5m" $rules }}])) > {{ dig "KongJwtAuthWsTicketRedisError" "threshold" 2 $rules }}
+        for: {{ dig "KongJwtAuthWsTicketRedisError" "for" "1m" $rules }}
+        labels:
+          severity: {{ dig "KongJwtAuthWsTicketRedisError" "severity" "critical" $rules }}
+          alertGroup: security-warnings
+          {{- with .Values.prometheus.defaultAlerts.securityWarnings.additionalLabels }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        annotations:
+          summary: "Kong JWT auth cannot reach Redis for WebSocket tickets"
+          description: |
+            Ticket mint or consume failed closed because Redis was unreachable or returned an error. WebSocket upgrades that require tickets will fail until Redis recovers.
+            Loki: `{app="gateway"} |= "Ticket" |= "Redis error"`
+{{- end }}
 {{- end -}}
 
 {{- define "kongPlugins.appRepoAuthRules" -}}

--- a/charts/kong-plugins/tests/unique-jwt-auth/handler_spec.lua
+++ b/charts/kong-plugins/tests/unique-jwt-auth/handler_spec.lua
@@ -506,7 +506,7 @@ describe("ticket consume", function()
         assert_falsy(retry.response, "ticket should still be valid after non-upgrade rejection")
     end)
 
-    it("rejects a ticket with the wrong scope", function()
+    it("rejects a ticket with the wrong scope without burning it", function()
         local mint_cfg = ticket_conf({
             ticket_scope = "ws:chat"
         })
@@ -525,6 +525,18 @@ describe("ticket consume", function()
         handler:access(consume_cfg)
         assert_equal(401, state.response.status)
         assert_any_contains("scope mismatch", state.warnings)
+
+        -- The misrouted attempt must not have consumed the ticket: it must
+        -- still work on the route with the scope it was minted for.
+        local retry = mock_kong.reset({
+            query = {
+                ticket = ticket
+            },
+            headers = upgrade_headers()
+        })
+        handler:access(mint_cfg)
+        assert_falsy(retry.response, "ticket should still be valid for its own scope")
+        assert_equal("user-123", retry.upstream_headers["x-user-id"])
     end)
 
     it("rejects a disallowed Origin", function()
@@ -624,14 +636,42 @@ describe("atomic consume", function()
         local hash = ws_ticket._sha256_hex(ticket)
         local key = ws_ticket._ticket_key(hash)
 
-        local first, ferr = redis_store.consume(cfg, key)
+        -- A wrong-scope consume must reject WITHOUT deleting the record.
+        local burned, berr = redis_store.consume(cfg, key, "ws:other")
+        assert_falsy(burned, "wrong-scope consume must not return the record")
+        assert_equal("scope mismatch", berr)
+
+        local first, ferr = redis_store.consume(cfg, key, cfg.ticket_scope)
         if not first then
             error("first consume should return the record: " .. tostring(ferr))
         end
 
-        local second, serr = redis_store.consume(cfg, key)
+        local second, serr = redis_store.consume(cfg, key, cfg.ticket_scope)
         assert_falsy(second, "second consume must not return a record")
         assert_equal("not found", serr)
+    end)
+
+    it("sets a TTL on rate-limit counters atomically", function()
+        -- INCR+EXPIRE run as one EVAL: the counter must never exist without
+        -- a TTL, or the rate limit would never reset.
+        local cfg = ticket_conf()
+        flush_redis(cfg)
+
+        local count, err = redis_store.incr_with_expiry(cfg, "mint:ttl-spec", 60)
+        if not count then
+            error("incr_with_expiry failed: " .. tostring(err))
+        end
+        assert_equal(1, count)
+
+        local redis = require "resty.redis"
+        local red = redis:new()
+        red:set_timeout(2000)
+        assert(red:connect(cfg.redis_host, cfg.redis_port))
+        assert(red:select(cfg.redis_database))
+        local ttl = red:ttl(cfg.redis_key_prefix .. "mint:ttl-spec")
+        red:set_keepalive(10000, 10)
+        assert_truthy(ttl and ttl > 0 and ttl <= 60,
+            "rate-limit counter must carry a TTL, got " .. tostring(ttl))
     end)
 
 end)

--- a/charts/kong-plugins/tests/unique-jwt-auth/handler_spec.lua
+++ b/charts/kong-plugins/tests/unique-jwt-auth/handler_spec.lua
@@ -1,0 +1,641 @@
+local runner = require "runner"
+local mock_kong = require "mock_kong"
+
+-- handler.lua captures the kong global at load time.
+mock_kong.install()
+
+local handler = require "kong.plugins.unique-jwt-auth.handler"
+local redis_store = require "kong.plugins.unique-jwt-auth.redis_store"
+local ws_ticket = require "kong.plugins.unique-jwt-auth.ws_ticket"
+local build = require("token_builder").build
+
+local describe = runner.describe
+local it = runner.it
+local assert_equal = runner.assert_equal
+local assert_truthy = runner.assert_truthy
+local assert_falsy = runner.assert_falsy
+local assert_any_contains = runner.assert_any_contains
+local assert_none_contains = runner.assert_none_contains
+
+local ALLOWED_ISSUER = "https://id.example.com"
+local ACCESS_TOKEN_SECRET = "offline-hs256-access-token-secret"
+local UNKNOWN_ISSUER = "https://not-our-idp.example.com"
+local RESOURCE_OWNER_CLAIM = "urn:zitadel:iam:user:resourceowner:id"
+local PROJECT_ID = "project-abc"
+local TICKET_SCOPE = "ws:graphql"
+
+local REDIS_HOST = os.getenv("REDIS_HOST") or "127.0.0.1"
+local REDIS_PORT = tonumber(os.getenv("REDIS_PORT") or "6379")
+-- Dedicated logical DB so specs can FLUSHDB without touching anything else.
+local REDIS_DB = 15
+
+local function redis_conf(overrides)
+    local base = {
+        redis_host = REDIS_HOST,
+        redis_port = REDIS_PORT,
+        redis_timeout_ms = 2000,
+        redis_database = REDIS_DB,
+        redis_key_prefix = "ws_ticket_test:",
+        redis_ssl = false,
+        ticket_scope = TICKET_SCOPE,
+        ticket_ttl = 20,
+        ticket_param_name = "ticket",
+        ticket_mint_path = "/auth/ticket",
+        ticket_mint_rate_limit = 0,
+        ticket_fail_rate_limit = 0,
+        ticket_allowed_origins = {},
+        ws_ticket_enabled = true
+    }
+    for key, value in pairs(overrides or {}) do
+        base[key] = value
+    end
+    return base
+end
+
+local function conf(overrides)
+    local base = {
+        uri_param_names = {"token"},
+        cookie_names = {},
+        header_names = {"authorization"},
+        claims_to_verify = {"exp"},
+        allowed_iss = {ALLOWED_ISSUER},
+        algorithm = "RS256",
+        maximum_expiration = 0,
+        consumer_match = false,
+        run_on_preflight = true,
+        security_warning_metric_name = "unique_jwt_auth_security_warnings_total",
+        zitadel_project_id = PROJECT_ID,
+        well_known_template = "%s/.well-known/openid-configuration",
+        ssl_verify = false,
+        ws_ticket_enabled = false
+    }
+    for key, value in pairs(overrides or {}) do
+        base[key] = value
+    end
+    return base
+end
+
+local function access_token(opts)
+    opts = opts or {}
+    local now = ngx.time()
+    local claims = {
+        iss = opts.iss or UNKNOWN_ISSUER,
+        sub = "user-123",
+        [RESOURCE_OWNER_CLAIM] = "company-456",
+        exp = now + 3600
+    }
+    for key, value in pairs(opts.claims or {}) do
+        claims[key] = value
+    end
+    for _, key in ipairs(opts.remove or {}) do
+        claims[key] = nil
+    end
+
+    return build({
+        typ = "JWT",
+        alg = opts.alg or "RS256"
+    }, claims, opts.secret or "irrelevant-these-never-reach-signature-checks")
+end
+
+local function verifiable_access_token(opts)
+    opts = opts or {}
+    opts.iss = opts.iss or ALLOWED_ISSUER
+    opts.alg = opts.alg or "HS256"
+    opts.secret = opts.secret or ACCESS_TOKEN_SECRET
+    return access_token(opts)
+end
+
+local function verifiable_conf(overrides)
+    local base = {
+        algorithm = "HS256",
+        allowed_iss = {ALLOWED_ISSUER}
+    }
+    for key, value in pairs(overrides or {}) do
+        base[key] = value
+    end
+    return conf(base)
+end
+
+local function ticket_conf(overrides)
+    local base = redis_conf({
+        algorithm = "HS256",
+        allowed_iss = {ALLOWED_ISSUER},
+        uri_param_names = {"token"},
+        cookie_names = {},
+        header_names = {"authorization"},
+        claims_to_verify = {"exp"},
+        maximum_expiration = 0,
+        consumer_match = false,
+        run_on_preflight = true,
+        security_warning_metric_name = "unique_jwt_auth_security_warnings_total",
+        zitadel_project_id = PROJECT_ID,
+        well_known_template = "%s/.well-known/openid-configuration",
+        ssl_verify = false
+    })
+    for key, value in pairs(overrides or {}) do
+        base[key] = value
+    end
+    return base
+end
+
+local function upgrade_headers(extra)
+    local headers = {
+        upgrade = "websocket",
+        connection = "Upgrade"
+    }
+    for key, value in pairs(extra or {}) do
+        headers[key] = value
+    end
+    return headers
+end
+
+local function flush_redis(conf_table)
+    local redis = require "resty.redis"
+    local red = redis:new()
+    red:set_timeout(2000)
+    local ok, err = red:connect(conf_table.redis_host, conf_table.redis_port)
+    if not ok then
+        error("redis connect to " .. tostring(conf_table.redis_host) .. ":" ..
+            tostring(conf_table.redis_port) .. " failed: " .. tostring(err))
+    end
+    local db = conf_table.redis_database or REDIS_DB
+    local sok, serr = red:select(db)
+    if not sok then
+        red:close()
+        error("redis SELECT failed: " .. tostring(serr))
+    end
+    local fok, ferr = red:flushdb()
+    if not fok then
+        red:close()
+        error("redis FLUSHDB failed: " .. tostring(ferr))
+    end
+    red:set_keepalive(10000, 10)
+end
+
+local function run()
+
+describe("JWT authentication (token path regression)", function()
+
+    it("rejects a token from a disallowed issuer", function()
+        local state = mock_kong.reset({
+            headers = {
+                authorization = "Bearer " .. access_token()
+            }
+        })
+
+        handler:access(conf())
+
+        assert_equal(401, state.response.status)
+        assert_any_contains("disallowed issuer", state.warnings)
+    end)
+
+    it("accepts a verifiable access token from the Authorization header", function()
+        local state = mock_kong.reset({
+            headers = {
+                authorization = "Bearer " .. verifiable_access_token()
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+
+        handler:access(verifiable_conf())
+
+        assert_falsy(state.response, "request should not have been rejected")
+        assert_equal("user-123", state.upstream_headers["x-user-id"])
+        assert_equal("company-456", state.upstream_headers["x-company-id"])
+    end)
+
+    it("accepts a verifiable JWT from ?token= with tickets disabled", function()
+        local state = mock_kong.reset({
+            query = {
+                token = verifiable_access_token()
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+
+        handler:access(verifiable_conf({
+            ws_ticket_enabled = false
+        }))
+
+        assert_falsy(state.response, "request should not have been rejected")
+        assert_equal("user-123", state.upstream_headers["x-user-id"])
+    end)
+
+    it("accepts a verifiable JWT from ?token= with tickets enabled", function()
+        -- Backward compatibility: ?token= must keep working when tickets are on.
+        local state = mock_kong.reset({
+            query = {
+                token = verifiable_access_token()
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+
+        handler:access(ticket_conf())
+
+        assert_falsy(state.response, "request should not have been rejected")
+        assert_equal("user-123", state.upstream_headers["x-user-id"])
+        assert_equal("company-456", state.upstream_headers["x-company-id"])
+    end)
+
+    it("rejects multiple tokens", function()
+        local state = mock_kong.reset({
+            query = {
+                token = verifiable_access_token()
+            },
+            headers = {
+                authorization = "Bearer " .. verifiable_access_token({
+                    claims = {
+                        sub = "other-user"
+                    }
+                })
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+
+        handler:access(verifiable_conf())
+
+        assert_equal(401, state.response.status)
+        assert_any_contains("Multiple tokens", state.warnings)
+    end)
+
+end)
+
+describe("ticket mint", function()
+
+    it("rejects mint without Authorization Bearer", function()
+        flush_redis(ticket_conf())
+        local state = mock_kong.reset({
+            method = "POST",
+            path = "/auth/ticket",
+            query = {
+                token = verifiable_access_token()
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+
+        handler:access(ticket_conf())
+
+        assert_equal(401, state.response.status)
+        assert_any_contains("missing Authorization Bearer", state.warnings)
+    end)
+
+    it("rejects mint with an invalid JWT", function()
+        flush_redis(ticket_conf())
+        local state = mock_kong.reset({
+            method = "POST",
+            path = "/auth/ticket",
+            headers = {
+                authorization = "Bearer " .. access_token()
+            }
+        })
+
+        handler:access(ticket_conf())
+
+        assert_equal(401, state.response.status)
+        assert_any_contains("disallowed issuer", state.warnings)
+    end)
+
+    it("rejects mint when identity claims are missing", function()
+        flush_redis(ticket_conf())
+        local state = mock_kong.reset({
+            method = "POST",
+            path = "/auth/ticket",
+            headers = {
+                authorization = "Bearer " .. verifiable_access_token({
+                    remove = {RESOURCE_OWNER_CLAIM}
+                })
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+
+        handler:access(ticket_conf())
+
+        assert_equal(401, state.response.status)
+        assert_any_contains("missing claim", state.warnings)
+    end)
+
+    it("mints an opaque ticket, stores only its hash, and never proxies", function()
+        local cfg = ticket_conf()
+        flush_redis(cfg)
+        local state = mock_kong.reset({
+            method = "POST",
+            path = "/auth/ticket",
+            headers = {
+                authorization = "Bearer " .. verifiable_access_token()
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+
+        handler:access(cfg)
+
+        assert_equal(200, state.response.status)
+        assert_equal("no-store", state.response.headers["Cache-Control"])
+        assert_truthy(state.response.body.ticket, "ticket missing from response")
+        assert_equal(20, state.response.body.expires_in)
+
+        -- Opaque: not a JWT (no two dots).
+        local dots = 0
+        for _ in state.response.body.ticket:gmatch("%.") do
+            dots = dots + 1
+        end
+        assert_equal(0, dots, "ticket must not be a JWT")
+
+        -- Raw ticket must not be stored; only the hash key may exist.
+        local hash = ws_ticket._sha256_hex(state.response.body.ticket)
+        local redis = require "resty.redis"
+        local red = redis:new()
+        red:set_timeout(2000)
+        assert(red:connect(cfg.redis_host, cfg.redis_port))
+        assert(red:select(cfg.redis_database))
+        local raw_hit = red:get(cfg.redis_key_prefix .. state.response.body.ticket)
+        assert_equal(ngx.null, raw_hit, "raw ticket must not be a Redis key")
+        local stored = red:get(cfg.redis_key_prefix .. ws_ticket._ticket_key(hash))
+        assert_truthy(stored and stored ~= ngx.null, "hash key missing")
+        assert_none_contains(state.response.body.ticket, {stored}, "raw ticket must not appear in the record")
+        assert_none_contains("eyJ", {stored}, "JWT material must not appear in the record")
+        red:set_keepalive(10000, 10)
+    end)
+
+    it("rate-limits minting per subject", function()
+        local cfg = ticket_conf({
+            ticket_mint_rate_limit = 2
+        })
+        flush_redis(cfg)
+
+        for i = 1, 2 do
+            local state = mock_kong.reset({
+                method = "POST",
+                path = "/auth/ticket",
+                headers = {
+                    authorization = "Bearer " .. verifiable_access_token()
+                },
+                cache_keys = {ACCESS_TOKEN_SECRET}
+            })
+            handler:access(cfg)
+            assert_equal(200, state.response.status, "mint " .. i .. " should succeed")
+        end
+
+        local state = mock_kong.reset({
+            method = "POST",
+            path = "/auth/ticket",
+            headers = {
+                authorization = "Bearer " .. verifiable_access_token()
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+        handler:access(cfg)
+        assert_equal(429, state.response.status)
+        assert_any_contains("rate-limited", state.warnings)
+    end)
+
+    it("fails closed with 503 when Redis is unreachable on mint", function()
+        local cfg = ticket_conf({
+            redis_host = "127.0.0.1",
+            redis_port = 1 -- nothing listening
+        })
+        local state = mock_kong.reset({
+            method = "POST",
+            path = "/auth/ticket",
+            headers = {
+                authorization = "Bearer " .. verifiable_access_token()
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+
+        handler:access(cfg)
+
+        assert_equal(503, state.response.status)
+        assert_any_contains("Redis error", state.errors)
+    end)
+
+end)
+
+describe("ticket consume", function()
+
+    local function mint_ticket(cfg)
+        local state = mock_kong.reset({
+            method = "POST",
+            path = "/auth/ticket",
+            headers = {
+                authorization = "Bearer " .. verifiable_access_token()
+            },
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+        handler:access(cfg)
+        assert_equal(200, state.response.status, "mint for consume setup")
+        return state.response.body.ticket
+    end
+
+    it("accepts a mint → upgrade round trip and strips the ticket param", function()
+        local cfg = ticket_conf()
+        flush_redis(cfg)
+        local ticket = mint_ticket(cfg)
+
+        local state = mock_kong.reset({
+            method = "GET",
+            path = "/graphql",
+            query = {
+                ticket = ticket,
+                foo = "bar"
+            },
+            headers = upgrade_headers()
+        })
+
+        handler:access(cfg)
+
+        assert_falsy(state.response, "upgrade should not have been rejected")
+        assert_equal("user-123", state.upstream_headers["x-user-id"])
+        assert_equal("company-456", state.upstream_headers["x-company-id"])
+        assert_truthy(state.cleared_headers["x-user-roles"])
+        assert_truthy(state.cleared_headers["x-company-name"])
+        assert_truthy(state.cleared_headers["x-company-domain"])
+        assert_truthy(state.query_set, "ticket query arg should have been rewritten")
+        assert_falsy(state.query_set.ticket, "ticket must be stripped before proxy")
+        assert_equal("bar", state.query_set.foo)
+    end)
+
+    it("rejects a second consume of the same ticket (single-use)", function()
+        local cfg = ticket_conf()
+        flush_redis(cfg)
+        local ticket = mint_ticket(cfg)
+
+        local first = mock_kong.reset({
+            query = {
+                ticket = ticket
+            },
+            headers = upgrade_headers()
+        })
+        handler:access(cfg)
+        assert_falsy(first.response, "first consume should succeed")
+
+        local second = mock_kong.reset({
+            query = {
+                ticket = ticket
+            },
+            headers = upgrade_headers()
+        })
+        handler:access(cfg)
+        assert_equal(401, second.response.status)
+        assert_any_contains("unknown/expired/replayed", second.warnings)
+    end)
+
+    it("rejects a ticket on a non-upgrade request without touching Redis after the check", function()
+        local cfg = ticket_conf()
+        flush_redis(cfg)
+        local ticket = mint_ticket(cfg)
+
+        local state = mock_kong.reset({
+            query = {
+                ticket = ticket
+            },
+            headers = {
+                -- no Upgrade
+            }
+        })
+        handler:access(cfg)
+        assert_equal(401, state.response.status)
+        assert_any_contains("non-upgrade", state.warnings)
+
+        -- Ticket must still be consumable afterwards (Redis was not drained).
+        local retry = mock_kong.reset({
+            query = {
+                ticket = ticket
+            },
+            headers = upgrade_headers()
+        })
+        handler:access(cfg)
+        assert_falsy(retry.response, "ticket should still be valid after non-upgrade rejection")
+    end)
+
+    it("rejects a ticket with the wrong scope", function()
+        local mint_cfg = ticket_conf({
+            ticket_scope = "ws:chat"
+        })
+        flush_redis(mint_cfg)
+        local ticket = mint_ticket(mint_cfg)
+
+        local consume_cfg = ticket_conf({
+            ticket_scope = "ws:speech"
+        })
+        local state = mock_kong.reset({
+            query = {
+                ticket = ticket
+            },
+            headers = upgrade_headers()
+        })
+        handler:access(consume_cfg)
+        assert_equal(401, state.response.status)
+        assert_any_contains("scope mismatch", state.warnings)
+    end)
+
+    it("rejects a disallowed Origin", function()
+        local cfg = ticket_conf({
+            ticket_allowed_origins = {"https://app.example.com"}
+        })
+        flush_redis(cfg)
+        local ticket = mint_ticket(cfg)
+
+        local state = mock_kong.reset({
+            query = {
+                ticket = ticket
+            },
+            headers = upgrade_headers({
+                origin = "https://evil.example.com"
+            })
+        })
+        handler:access(cfg)
+        assert_equal(401, state.response.status)
+        assert_any_contains("Origin rejected", state.warnings)
+    end)
+
+    it("accepts an exact-match Origin", function()
+        local cfg = ticket_conf({
+            ticket_allowed_origins = {"https://app.example.com"}
+        })
+        flush_redis(cfg)
+        local ticket = mint_ticket(cfg)
+
+        local state = mock_kong.reset({
+            query = {
+                ticket = ticket
+            },
+            headers = upgrade_headers({
+                origin = "https://app.example.com"
+            })
+        })
+        handler:access(cfg)
+        assert_falsy(state.response, "exact Origin should be accepted")
+        assert_equal("user-123", state.upstream_headers["x-user-id"])
+    end)
+
+    it("does not fall through to the token path when ?ticket= is present", function()
+        local cfg = ticket_conf()
+        flush_redis(cfg)
+
+        local state = mock_kong.reset({
+            query = {
+                ticket = "forged-ticket",
+                token = verifiable_access_token()
+            },
+            headers = upgrade_headers(),
+            cache_keys = {ACCESS_TOKEN_SECRET}
+        })
+        handler:access(cfg)
+
+        assert_equal(401, state.response.status)
+        -- Must not have stamped identity from the JWT fallback.
+        assert_falsy(state.upstream_headers["x-user-id"])
+    end)
+
+    it("fails closed with 503 when Redis is unreachable on consume", function()
+        local cfg = ticket_conf({
+            redis_host = "127.0.0.1",
+            redis_port = 1
+        })
+        local state = mock_kong.reset({
+            query = {
+                ticket = "anything"
+            },
+            headers = upgrade_headers()
+        })
+        handler:access(cfg)
+        assert_equal(503, state.response.status)
+    end)
+
+end)
+
+describe("atomic consume", function()
+
+    it("returns the record once and misses on the second consume", function()
+        -- redis_store.consume uses a single EVAL (GET+DEL). Redis executes
+        -- EVAL atomically, so two concurrent consumers cannot both win; this
+        -- spec proves the script removes the key on first success.
+        local cfg = ticket_conf()
+        flush_redis(cfg)
+
+        local claims = {
+            sub = "user-123",
+            [RESOURCE_OWNER_CLAIM] = "company-456"
+        }
+        local ticket, mint_result = ws_ticket.mint(cfg, claims)
+        if not ticket then
+            error("mint failed: " .. tostring(mint_result and mint_result.reason))
+        end
+
+        local hash = ws_ticket._sha256_hex(ticket)
+        local key = ws_ticket._ticket_key(hash)
+
+        local first, ferr = redis_store.consume(cfg, key)
+        if not first then
+            error("first consume should return the record: " .. tostring(ferr))
+        end
+
+        local second, serr = redis_store.consume(cfg, key)
+        assert_falsy(second, "second consume must not return a record")
+        assert_equal("not found", serr)
+    end)
+
+end)
+
+end -- run()
+
+return run

--- a/charts/kong-plugins/tests/unique-jwt-auth/mock_kong.lua
+++ b/charts/kong-plugins/tests/unique-jwt-auth/mock_kong.lua
@@ -1,0 +1,165 @@
+-------------------------------------------------------------------------------
+-- Stand-in for the `kong` PDK global.
+--
+-- handler.lua captures `local kong = kong` at load time, so the global must
+-- exist before the plugin is required and keep the same identity for the run.
+-- install() creates it once; reset() swaps mutable state between specs.
+-------------------------------------------------------------------------------
+
+local M = {}
+
+local state
+
+local function new_state(options)
+    options = options or {}
+    return {
+        method = options.method or "GET",
+        path = options.path or "/graphql",
+        query = options.query or {},
+        headers = options.headers or {},
+        forwarded_ip = options.forwarded_ip or "10.0.0.1",
+        credential = options.credential,
+        -- When set, kong.cache:get returns this keyset without calling the
+        -- loader, so HS256 specs can pass Zitadel verification offline.
+        cache_keys = options.cache_keys,
+        upstream_headers = {},
+        cleared_headers = {},
+        query_set = nil,
+        warnings = {},
+        errors = {},
+        response = nil
+    }
+end
+
+local function header_value(name)
+    local value = state.headers[name] or state.headers[name:lower()]
+    return value
+end
+
+local function concat_log_args(...)
+    local n = select("#", ...)
+    if n == 0 then
+        return ""
+    end
+    local parts = {}
+    for i = 1, n do
+        parts[i] = tostring(select(i, ...))
+    end
+    return table.concat(parts)
+end
+
+--- Install the mock as the `kong` global. Call before requiring the plugin.
+function M.install()
+    state = new_state()
+
+    local function record_response(status, body, headers)
+        state.response = {
+            status = status,
+            body = body,
+            headers = headers
+        }
+        -- kong.response.exit never returns in production; in specs the caller
+        -- sees the returned table and stops further handler work.
+        return state.response
+    end
+
+    _G.kong = {
+        request = {
+            get_method = function()
+                return state.method
+            end,
+            get_path = function()
+                return state.path
+            end,
+            get_query = function()
+                return state.query
+            end,
+            get_headers = function()
+                return state.headers
+            end,
+            get_header = function(name)
+                return header_value(name)
+            end
+        },
+        response = {
+            exit = record_response
+        },
+        service = {
+            request = {
+                set_header = function(name, value)
+                    state.upstream_headers[name] = value
+                end,
+                clear_header = function(name)
+                    state.cleared_headers[name] = true
+                    state.upstream_headers[name] = nil
+                end,
+                set_query = function(args)
+                    state.query_set = args
+                    state.query = args
+                end
+            }
+        },
+        client = {
+            get_forwarded_ip = function()
+                return state.forwarded_ip
+            end,
+            get_credential = function()
+                return state.credential
+            end,
+            authenticate = function()
+            end
+        },
+        cache = {
+            get = function(_, key, _, cb, ...)
+                if state.cache_keys then
+                    return {
+                        keys = state.cache_keys,
+                        updated_at = ngx.time()
+                    }
+                end
+                if cb then
+                    return cb(...)
+                end
+                return nil, "kong.cache stub has no cache_keys and no loader for " .. tostring(key)
+            end,
+            invalidate = function()
+            end
+        },
+        log = {
+            debug = function()
+            end,
+            notice = function()
+            end,
+            info = function()
+            end,
+            warn = function(...)
+                state.warnings[#state.warnings + 1] = concat_log_args(...)
+            end,
+            err = function(...)
+                state.errors[#state.errors + 1] = concat_log_args(...)
+            end
+        },
+        ctx = {
+            shared = {}
+        },
+        worker_events = {
+            register = function()
+            end
+        }
+    }
+
+    return M
+end
+
+--- Start a fresh request. Returns the observation table for assertions.
+function M.reset(options)
+    state = new_state(options)
+    _G.kong.ctx.shared = {}
+    return state
+end
+
+function M.state()
+    return state
+end
+
+return M

--- a/charts/kong-plugins/tests/unique-jwt-auth/run.lua
+++ b/charts/kong-plugins/tests/unique-jwt-auth/run.lua
@@ -1,0 +1,65 @@
+-- Entry point for the unique-jwt-auth specs. See run.sh.
+--
+-- The resty CLI wraps the main chunk in xpcall (init_worker), which forbids
+-- cosocket yields. Schedule the suite on a timer + light thread so Redis can
+-- yield. Specs are required first (definition only) and run() afterward —
+-- cosockets cannot run while still inside require().
+package.path = "/spec/?.lua;" .. package.path
+
+local finished = false
+local exit_code = 1
+
+io.stdout:setvbuf("no")
+io.stderr:setvbuf("no")
+
+local ok, err = ngx.timer.at(0, function(premature)
+    if premature then
+        finished = true
+        return
+    end
+
+    local thread, spawn_err = ngx.thread.spawn(function()
+        local runner = require "runner"
+        local run_specs = require "handler_spec"
+        run_specs()
+        return runner.report()
+    end)
+
+    if not thread then
+        io.stderr:write("failed to spawn test thread: " .. tostring(spawn_err) .. "\n")
+        exit_code = 1
+        finished = true
+        return
+    end
+
+    local waited, result = ngx.thread.wait(thread)
+    if waited then
+        exit_code = result
+    else
+        if type(result) == "table" then
+            local cjson = require "cjson.safe"
+            io.stderr:write("FATAL: " .. (cjson.encode(result) or tostring(result)) .. "\n")
+        else
+            io.stderr:write("FATAL: " .. tostring(result) .. "\n")
+        end
+        exit_code = 1
+    end
+    finished = true
+end)
+
+if not ok then
+    io.stderr:write("failed to schedule test timer: " .. tostring(err) .. "\n")
+    os.exit(1)
+end
+
+local deadline = ngx.now() + 90
+while not finished and ngx.now() < deadline do
+    ngx.sleep(0.05)
+end
+
+if not finished then
+    io.stderr:write("test suite timed out\n")
+    os.exit(1)
+end
+
+os.exit(exit_code)

--- a/charts/kong-plugins/tests/unique-jwt-auth/run.sh
+++ b/charts/kong-plugins/tests/unique-jwt-auth/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Run the unique-jwt-auth specs inside the official Kong image against a real
+# Redis container, so atomic ticket consumption is exercised for real.
+#
+# Usage: ./run.sh [kong-image]
+
+set -euo pipefail
+
+# Digest-pinned so CI and local runs hit the same OpenResty/Kong/Redis bits.
+# Bump tag and digest together by hand — this repo has no Renovate coverage
+# for these test images. Override Kong with a positional argument when
+# bisecting (e.g. ./run.sh kong/kong:3.4).
+KONG_IMAGE="${1:-kong/kong:3.3@sha256:231de5c033386b87c09f2c6360e2b2de0b8072dffc9329c3600a3820479e4b8f}"
+REDIS_IMAGE="${REDIS_IMAGE:-redis:7.2-alpine@sha256:05a97a479bc73de66f087dc05b569010772880f778cc8671fa6b8aadee32e5c6}"
+
+SPEC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "${SPEC_DIR}/../../files/unique-jwt-auth" && pwd)"
+
+NETWORK="kong-plugin-test-$$"
+REDIS_NAME="kong-plugin-test-redis-$$"
+
+cleanup() {
+  docker rm -f "${REDIS_NAME}" >/dev/null 2>&1 || true
+  docker network rm "${NETWORK}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+docker network create "${NETWORK}" >/dev/null
+
+docker run -d --rm \
+  --name "${REDIS_NAME}" \
+  --network "${NETWORK}" \
+  "${REDIS_IMAGE}" \
+  >/dev/null
+
+# Wait until Redis answers PING, then resolve its IP so the Kong container
+# does not depend on Docker DNS inside OpenResty cosockets.
+REDIS_IP=""
+for _ in $(seq 1 50); do
+  if docker run --rm --network "${NETWORK}" --entrypoint redis-cli "${REDIS_IMAGE}" \
+      -h "${REDIS_NAME}" ping 2>/dev/null | grep -q PONG; then
+    REDIS_IP="$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${REDIS_NAME}")"
+    break
+  fi
+  sleep 0.2
+done
+
+if [[ -z "${REDIS_IP}" ]]; then
+  echo "Redis did not become ready" >&2
+  exit 1
+fi
+
+docker run --rm \
+  --network "${NETWORK}" \
+  --entrypoint /usr/local/openresty/bin/resty \
+  --env "REDIS_HOST=${REDIS_IP}" \
+  --env "REDIS_PORT=6379" \
+  --volume "${PLUGIN_DIR}:/usr/local/share/lua/5.1/kong/plugins/unique-jwt-auth:ro" \
+  --volume "${SPEC_DIR}:/spec:ro" \
+  "${KONG_IMAGE}" \
+  --errlog-level crit \
+  /spec/run.lua

--- a/charts/kong-plugins/tests/unique-jwt-auth/runner.lua
+++ b/charts/kong-plugins/tests/unique-jwt-auth/runner.lua
@@ -1,0 +1,96 @@
+-------------------------------------------------------------------------------
+-- Minimal spec runner for the official Kong image.
+--
+-- Specs run under `resty` so they get a real ngx API. The Kong image has no C
+-- toolchain, so busted cannot be installed there; this provides the small
+-- describe/it/assert subset the plugin specs use.
+-------------------------------------------------------------------------------
+
+local M = {}
+
+local passed = 0
+local failures = {}
+local group = "(root)"
+
+function M.describe(name, fn)
+    local previous = group
+    group = previous == "(root)" and name or (previous .. " " .. name)
+    fn()
+    group = previous
+end
+
+function M.it(name, fn)
+    -- Specs run inside an ngx.timer + light thread (see run.lua), which
+    -- allows cosocket yields. Do not wrap in pcall/xpcall — those cross a
+    -- C-call boundary and reject yields. A failing assertion aborts the
+    -- suite; that is acceptable for this harness.
+    fn()
+    passed = passed + 1
+    io.write(".")
+    io.flush()
+end
+
+local function describe_value(value)
+    if type(value) == "string" then
+        return string.format("%q", value)
+    end
+    return tostring(value)
+end
+
+function M.assert_equal(expected, actual, context)
+    if expected ~= actual then
+        error(string.format("%sexpected %s but got %s", context and (context .. ": ") or "", describe_value(expected),
+            describe_value(actual)), 2)
+    end
+end
+
+function M.assert_truthy(value, context)
+    if not value then
+        error(string.format("%sexpected a truthy value but got %s", context and (context .. ": ") or "",
+            describe_value(value)), 2)
+    end
+end
+
+function M.assert_falsy(value, context)
+    if value then
+        error(string.format("%sexpected a falsy value but got %s", context and (context .. ": ") or "",
+            describe_value(value)), 2)
+    end
+end
+
+function M.assert_contains(needle, haystack, context)
+    if type(haystack) ~= "string" or not haystack:find(needle, 1, true) then
+        error(string.format("%sexpected %s to contain %s", context and (context .. ": ") or "",
+            describe_value(haystack), describe_value(needle)), 2)
+    end
+end
+
+function M.assert_none_contains(needle, list, context)
+    for _, entry in ipairs(list) do
+        if type(entry) == "string" and entry:find(needle, 1, true) then
+            error(string.format("%sexpected nothing to contain %s, but found %s",
+                context and (context .. ": ") or "", describe_value(needle), describe_value(entry)), 2)
+        end
+    end
+end
+
+function M.assert_any_contains(needle, list, context)
+    for _, entry in ipairs(list) do
+        if type(entry) == "string" and entry:find(needle, 1, true) then
+            return
+        end
+    end
+    error(string.format("%sexpected one of %d entries to contain %s", context and (context .. ": ") or "", #list,
+        describe_value(needle)), 2)
+end
+
+function M.report()
+    io.write("\n\n")
+    for _, failure in ipairs(failures) do
+        io.write(string.format("FAILED: %s\n  %s\n    %s\n\n", failure.group, failure.name, failure.err))
+    end
+    io.write(string.format("%d passed, %d failed\n", passed, #failures))
+    return #failures == 0 and 0 or 1
+end
+
+return M

--- a/charts/kong-plugins/tests/unique-jwt-auth/token_builder.lua
+++ b/charts/kong-plugins/tests/unique-jwt-auth/token_builder.lua
@@ -1,0 +1,28 @@
+-------------------------------------------------------------------------------
+-- Builds JWTs for the handler specs.
+--
+-- Independent of ws_ticket.lua so specs can forge expired, mismatched, or
+-- otherwise invalid tokens the minter would never emit.
+-------------------------------------------------------------------------------
+
+local cjson = require "cjson.safe"
+local hmac = require "resty.openssl.hmac"
+
+local M = {}
+
+local function base64url(input)
+    return (ngx.encode_base64(input, true):gsub("%+", "-"):gsub("/", "_"))
+end
+
+--- Assemble a JWT from an explicit header and claim set, HMAC-signed.
+function M.build(header, claims, secret)
+    local signing_input = base64url(cjson.encode(header)) .. "." .. base64url(cjson.encode(claims))
+
+    local mac = assert(hmac.new(secret, "sha256"))
+    assert(mac:update(signing_input))
+    local signature = assert(mac:final())
+
+    return signing_input .. "." .. base64url(signature)
+end
+
+return M

--- a/charts/kong-plugins/values.yaml
+++ b/charts/kong-plugins/values.yaml
@@ -117,6 +117,51 @@ prometheus:
           threshold: 2
           interval: "5m"
 
+        # Fires when sum(increase(kong_unique_jwt_auth_security_warnings_total{reason="ws_ticket_unknown"}[interval])) > threshold.
+        # Measures: forged, expired, replayed, or non-upgrade presentations of single-use WebSocket tickets.
+        KongJwtAuthWsTicketUnknown:
+          enabled: true
+          for: "0m"
+          severity: warning
+          threshold: 5
+          interval: "5m"
+
+        # Fires when sum(increase(kong_unique_jwt_auth_security_warnings_total{reason="ws_ticket_scope_mismatch"}[interval])) > threshold.
+        # Measures: tickets presented on a different route/service than they were minted for.
+        KongJwtAuthWsTicketScopeMismatch:
+          enabled: true
+          for: "0m"
+          severity: critical
+          threshold: 2
+          interval: "5m"
+
+        # Fires when sum(increase(kong_unique_jwt_auth_security_warnings_total{reason="ws_ticket_origin_rejected"}[interval])) > threshold.
+        # Measures: ticket upgrades whose Origin header was missing or not on the exact allowlist.
+        KongJwtAuthWsTicketOriginRejected:
+          enabled: true
+          for: "0m"
+          severity: warning
+          threshold: 2
+          interval: "5m"
+
+        # Fires when sum(increase(kong_unique_jwt_auth_security_warnings_total{reason="ws_ticket_mint_rate_limited"}[interval])) > threshold.
+        # Measures: authenticated subjects that exceeded ticket_mint_rate_limit.
+        KongJwtAuthWsTicketMintRateLimited:
+          enabled: true
+          for: "0m"
+          severity: warning
+          threshold: 10
+          interval: "5m"
+
+        # Fires when sum(increase(kong_unique_jwt_auth_security_warnings_total{reason="ws_ticket_redis_error"}[interval])) > threshold.
+        # Measures: ticket mint/consume failures caused by Redis unavailability (fail-closed).
+        KongJwtAuthWsTicketRedisError:
+          enabled: true
+          for: "1m"
+          severity: critical
+          threshold: 2
+          interval: "5m"
+
         # Fires when sum(increase(kong_unique_app_repo_auth_security_warnings_total{reason="api_key_validation_failed"}[interval])) > threshold.
         # Measures: count of requests where the app repository returned a non-200 response for the provided API key.
         # Individual failures are expected (revoked keys, typos). A large sustained surge indicates brute-forcing or a misconfigured client.


### PR DESCRIPTION
## Describe your changes

Browsers cannot set an `Authorization` header on a WebSocket handshake, so clients append their Zitadel access token to the URL, where it lands in gateway access logs, browser history and `Referer` headers ([CWE-598](https://cwe.mitre.org/data/definitions/598.html)).

`unique-jwt-auth` can now exchange a Zitadel JWT for a **single-use opaque ticket**. Kong mints a cryptographically random value (256 bits, not a JWT), stores only its **SHA-256 hash** in Redis alongside identity + scope + a 15-30s TTL, and on the upgrade **atomically retrieves-and-deletes** it. What sits in the URL is no longer a credential worth stealing, and it works exactly once.

Zitadel stays the single source of truth for identity but is **not** the ticket issuer. This avoids the introspect-then-revoke race that made an earlier design unusable: two concurrent upgrades could both introspect a token as valid before either revoke landed. A single Redis `EVAL` (`GET`+`DEL`) makes consumption atomic, so exactly one concurrent request can win.

### Why Redis

Kong OSS has **no shared storage across replicas**: `kong.cache` and `lua_shared_dict` are per-pod, and DB-less / hybrid data planes have no database. A ticket minted on pod A must be consumable exactly once on pod B, so the store has to be external. Redis is the pattern Kong's own rate-limiting and ACME plugins use, and `lua-resty-redis` ships in the Kong image, so there is no new runtime dependency.

### Backward and forward compatibility (load-bearing)

Everything new sits behind `ws_ticket_enabled` (default `false`).

- Flag **off** -> behaviour is identical to `main`.
- Flag **on** -> `?token=` (and cookie / `Authorization`) keep working unchanged. The new path is selected **only** when `?ticket=` is present, and it is exclusive (no fallback to the token path on a bad ticket, to prevent probing).

The existing `do_authentication` verification was extracted into a shared `verify_zitadel_token` helper so mint enforces exactly the same bar; the two cannot drift. A regression spec asserts the `?token=` path is identical with the flag on and off.

## Existing flow today (unchanged, this is the problem we are fixing)

The upgrade carries the full Zitadel access token in the URL. Kong verifies it and proxies, but the long-lived JWT now sits in gateway access logs, browser history and `Referer` for the life of the connection, and can be replayed until it expires.

```mermaid
sequenceDiagram
    autonumber
    participant C as Browser client
    participant K as Kong unique-jwt-auth
    participant Z as Zitadel
    participant U as Upstream service

    Note over C,U: One step - the long-lived access token is the credential in the URL
    C->>K: GET graphql with token, Upgrade websocket
    K->>K: retrieve_tokens - read from query, cookie, or Authorization
    K->>Z: verify issuer, alg, signature, claims
    Z-->>K: JWKS
    K->>K: stamp x-user-id, x-company-id, x-company-name, x-company-domain, x-user-roles
    K->>U: proxy the upgrade, token stays in the request URL
    U-->>C: 101 Switching Protocols
    Note over C,U: The same JWT is replayable until it expires and is now in logs and history
```

## How it works

```mermaid
sequenceDiagram
    autonumber
    participant C as Browser client
    participant K as Kong unique-jwt-auth
    participant Z as Zitadel
    participant R as Redis
    participant U as Upstream service

    Note over C,U: Step 1 mint - access token travels in a header, never in a URL
    C->>K: POST /auth/ticket with Bearer access token
    K->>Z: verify issuer, alg, signature, claims
    Z-->>K: JWKS
    K->>K: generate 256-bit opaque ticket, hash is sha256 of ticket
    K->>R: SET ws_ticket-hash record EX ttl NX
    K-->>C: 200 ticket and expires_in, Cache-Control no-store

    Note over C,U: Step 2 upgrade - only the short-lived ticket is in the URL
    C->>K: GET graphql with ticket param, Upgrade websocket
    K->>K: require upgrade, Origin allowlist, scope
    K->>R: EVAL GET then DEL ws_ticket-hash atomically
    R-->>K: record or nil if replayed or expired
    K->>K: stamp x-user-id and x-company-id, clear roles name domain, strip ticket param
    K->>U: proxy the upgrade
    U-->>C: 101 Switching Protocols
```

## What the plugin decides on every request

```mermaid
flowchart TD
    A["access()"] --> B{"ws_ticket_enabled?"}
    B -- no --> E["Existing path unchanged:<br/>token query, cookie, or Authorization"]
    B -- yes --> C{"POST to ticket_mint_path?"}
    C -- yes --> M["Mint: verify Zitadel JWT from Authorization only,<br/>store hash in Redis, answer directly, never proxied"]
    C -- no --> D{"ticket param present?"}
    D -- no --> E
    D -- yes --> T["Consume exclusively: upgrade + Origin + scope,<br/>atomic GET then DEL, stamp identity, proxy"]
```

## The details that make a ticket safe

- **Opaque, not a JWT.** The value carries no claims; all authority lives in the Redis record, which the client never sees.
- **Hash-only at rest.** Only `sha256(ticket)` is stored. The original Zitadel JWT is never stored, and a Redis dump cannot be replayed.
- **Single-use via atomic consume.** `EVAL` `GET`+`DEL` removes the record on first read; a second or concurrent consume misses. No introspect/revoke race.
- **A ticket cannot mint a ticket.** Mint accepts the credential from the `Authorization` header only - never query or cookie - so the short lifetime is not renewable.
- **Bound to one socket.** `ticket_scope` is written at mint and checked on consume, so a chat ticket cannot open a speech socket.
- **Upgrade-only + Origin allowlist.** Tickets are honoured only on a genuine `Upgrade: websocket` request and, when configured, an exact-match `Origin`.
- **Least privilege upstream.** Only `x-user-id` / `x-company-id` are stamped; `x-user-roles`, `x-company-name`, `x-company-domain` are actively cleared (the backend re-authenticates on `ConnectionInit`).
- **Fail closed.** If Redis is unreachable, mint and consume return 503 - never fail open.
- **Rate limited.** Mint per subject and failed consumption per IP, both in Redis.

## New configuration

| Setting | Default | What it does |
| --- | --- | --- |
| `ws_ticket_enabled` | `false` | Master switch. Off = identical to previous behaviour. |
| `ticket_param_name` | `ticket` | Query parameter carrying the opaque ticket. |
| `ticket_mint_path` | `/auth/ticket` | Path the plugin answers itself for minting. |
| `ticket_ttl` | `20` | Ticket lifetime in seconds, bounded 5-60. |
| `ticket_scope` | - | Route/service binding, written into the record and checked on consume. Required when enabled. |
| `ticket_allowed_origins` | `[]` | Exact `Origin` allowlist on consume. Empty = not enforced. |
| `ticket_mint_rate_limit` | `60` | Max mints per subject per 60s. `0` disables. |
| `ticket_fail_rate_limit` | `30` | Max failed consumptions per IP per 60s. `0` disables. |
| `redis_host` / `redis_port` | - / `6379` | Redis endpoint reachable from every Kong replica. |
| `redis_password` | - | `referenceable` + `encrypted`, so Kong vault references work. |
| `redis_ssl` / `redis_ssl_verify` | `false` / `true` | TLS to Redis. |
| `redis_timeout_ms` | `2000` | Connect/read timeout. |
| `redis_database` | `7` | Logical Redis DB. Claimed in the monorepo Redis registry (`infrastructure/redis.md`). Redis Cluster has no `SELECT` — set `0` and rely on `redis_key_prefix`. |
| `redis_key_prefix` | `ws_ticket:` | Key prefix for records and rate-limit counters. |

Also adds five alerts (`ws_ticket_unknown`, `ws_ticket_scope_mismatch`, `ws_ticket_origin_rejected`, `ws_ticket_mint_rate_limited`, `ws_ticket_redis_error`).

## Rollout

Both the flag and each tenant's migration are independent, so **merging changes no existing behaviour**.

1. Deploy with `ws_ticket_enabled: false`. Nothing changes.
2. Provision Redis (see infra checklist) and enable `ws_ticket_enabled` per tenant.
3. Migrate clients from `?token=` to `?ticket=` at their own pace - both are accepted while the flag is on.

## Test plan

`ct` only renders the ConfigMap that carries the Lua plugins; it never executes them. This PR adds a from-scratch spec harness that runs the plugin inside the pinned Kong image against a **real Redis container**, so atomic single-use consumption is exercised for real rather than stubbed.

```shell
./charts/kong-plugins/tests/unique-jwt-auth/run.sh   # 21 passed, 0 failed
```

- [x] 21 specs pass, wired into CI as the new `kong-plugin-test` job
- [x] `?token=` regression: identical behaviour with `ws_ticket_enabled` on and off
- [x] mint: rejects query/cookie credentials, rejects missing identity claims, 401 on invalid JWT, 429 on rate limit, response never proxied, **stored value is the hash and contains no JWT**
- [x] consume: mint -> upgrade round trip; second consume fails (single-use); non-upgrade rejected without draining the ticket; wrong scope rejected without burning the ticket; Origin mismatch rejected; `?ticket=` stripped before proxy; `?ticket=` never falls through to the token path
- [x] Redis down -> 503 on mint and consume (fail closed)
- [x] `helm-docs` regenerated; Chart bumped 2.4.0 -> 2.5.0 with ArtifactHub changelog

## Checklist before requesting a review
- [x] [`Contribution Guideline`](https://github.com/Unique-AG/helm-charts/blob/main/CONTRIBUTING.md) read and understood
- [x] Chart version bumped (`Chart.yaml`) - `2.4.0` -> `2.5.0`
- [x] Values schema updated - n/a, `kong-plugins` ships no values schema; the new fields are Kong plugin config (`schema.lua`), not chart values
- [x] Changes updated in [ArtifactHub syntax](https://artifacthub.io/docs/topics/annotations/helm) (`Chart.yaml`)
- [x] Pre-Commit passed or has been run manually

## Infra / sol-eng checklist (not solvable in this repo)

- [ ] **Provision Redis** reachable from every Kong replica in each tenant/topology. A ticket minted on one pod must be consumable on any other.
- [ ] **Deliver the Redis password via Kong vault** and reference it as `redis_password: '{vault://.../kong-ws-ticket-redis-password}'` (`referenceable` + `encrypted`). Never inline the secret.
- [ ] **Confirm Kong replica topology and mode** (DB-less under KIC assumed) and the Redis latency budget - consume happens inline on the upgrade.
- [ ] **Network policy / egress**: allow Kong pods to reach Redis (and TLS if `redis_ssl`).
- [ ] **Redact the `ticket` query parameter** in ingress, WAF, and tracing/error logs. The plugin strips it from the upstream request only; it cannot control Kong's own access log line or upstream infra.
- [ ] **Decide TTL** against socket.io / browser-extension reconnect backoff. Default 20s (bounded 5-60); Konstantin's target is 15-30s. If a client can take longer than the TTL between mint and connect, it will fail its own reconnect.
- [ ] **Fail-closed acknowledged**: if Redis is down, ticket upgrades return 503 until it recovers (`ws_ticket_redis_error` alert fires). REST and the `?token=` path are unaffected.

## Notes for reviewers

- Restarted from `main` rather than continuing the introspection branch; the old PR is closed separately. The introspection/revoke approach is intentionally gone.
- Client-side migration (chat, speech, browser-extension) follows in the monorepo.
- The spec harness runs under `resty` inside the Kong image (no busted/C toolchain there); it schedules the suite on an `ngx.timer` + light thread so Redis cosockets can yield. Images are digest-pinned in `run.sh` per the supply-chain rule; bump tag and digest together when moving Kong or Redis.

Made with [Cursor](https://cursor.com)

